### PR TITLE
feat(workflow): add support for different workflows; workflow registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ uv run orcha run
 
 # Or start them individually
 uv run orcha run server     # FastAPI dev server
-uv run orcha run workers    # Temporal worker
+uv run orcha run workers    # Temporal worker for the default queue
+
+# Run a worker for a specific queue
+uv run orcha run workers --task-queue low-priority
 ```
 
 ## Authentication
@@ -153,14 +156,15 @@ export OLLAMA_BASE_URL="http://localhost:11434/v1"
 
 ## CLI Reference
 
-| Command                | Description                              |
-|------------------------| ---------------------------------------- |
-| `orcha services start` | Start PostgreSQL + Temporal via Docker   |
-| `orcha services stop`  | Stop all Docker services                 |
-| `orcha init-db`        | Create database tables from models       |
-| `orcha run`            | Start both server and worker             |
-| `orcha run server`     | Start FastAPI dev server only            |
-| `orcha run workers`    | Start Temporal worker only               |
+| Command                            | Description                               |
+|------------------------------------|-------------------------------------------|
+| `orcha services start`             | Start PostgreSQL + Temporal via Docker    |
+| `orcha services stop`              | Stop all Docker services                  |
+| `orcha init-db`                    | Create database tables from models        |
+| `orcha run`                        | Start server and default-queue worker     |
+| `orcha run server`                 | Start FastAPI dev server only             |
+| `orcha run workers`                | Start Temporal worker for default queue   |
+| `orcha run workers --task-queue Q` | Start Temporal worker for a specific queue |
 
 ## Useful Commands
 

--- a/app/activities/__init__.py
+++ b/app/activities/__init__.py
@@ -1,7 +1,18 @@
-"""Activities for the Orcha-workflows application."""
+"""Activities for the Orcha application."""
 
 from .extract_metadata import extract_metadata_with_llm
 from .extract_pdf_content import extract_pdf_text
 from .store_workflow_result import store_workflow_result
 
-__all__ = ["extract_pdf_text", "extract_metadata_with_llm", "store_workflow_result"]
+REGISTERED_ACTIVITIES = [
+    extract_pdf_text,
+    extract_metadata_with_llm,
+    store_workflow_result,
+]
+
+__all__ = [
+    "REGISTERED_ACTIVITIES",
+    "extract_pdf_text",
+    "extract_metadata_with_llm",
+    "store_workflow_result",
+]

--- a/app/activities/extract_metadata.py
+++ b/app/activities/extract_metadata.py
@@ -8,7 +8,7 @@ from pydantic_ai.providers.ollama import OllamaProvider
 from temporalio import activity
 
 from app.config import get_settings
-from app.workflows.suggestions import MetadataResult
+from app.schemas.metadata_suggestions import MetadataSuggestions
 
 
 def _parse_llm(llm: str) -> tuple[str, str]:
@@ -74,13 +74,13 @@ def _create_model() -> OpenAIChatModel:
 @activity.defn
 async def extract_metadata_with_llm(
     request: ExtractMetadataRequest,
-) -> MetadataResult:
+) -> MetadataSuggestions:
     """Generate typed metadata suggestions using an LLM."""
     model = _create_model()
     agent = Agent(
         model=model,
         instructions=INSTRUCTIONS,
-        output_type=MetadataResult,
+        output_type=MetadataSuggestions,
     )
 
     result = await agent.run(request.text)

--- a/app/activities/extract_metadata.py
+++ b/app/activities/extract_metadata.py
@@ -77,7 +77,7 @@ async def extract_metadata_with_llm(
 ) -> MetadataSuggestions:
     """Generate typed metadata suggestions using an LLM."""
     model = _create_model()
-    agent = Agent(
+    agent = Agent[None, MetadataSuggestions](
         model=model,
         instructions=INSTRUCTIONS,
         output_type=MetadataSuggestions,

--- a/app/cli/main.py
+++ b/app/cli/main.py
@@ -71,11 +71,14 @@ def server():
 
 
 @run_app.command()
-def workers():
+def workers(task_queue: str | None = None):
     """Start the Temporal worker."""
     typer.echo("Starting Temporal worker...")
+    command = ["uv", "run", "python", "-m", "app.workers"]
+    if task_queue is not None:
+        command.extend(["--task-queue", task_queue])
     result = subprocess.run(
-        ["uv", "run", "python", "-m", "app.workers"],
+        command,
         cwd=PROJECT_ROOT,
     )
     sys.exit(result.returncode)

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -25,6 +25,7 @@ class Workflow(SQLModel, table=True):
 
     id: int | None = Field(default=None, primary_key=True)
     public_id: str = Field(default_factory=nanoid)
+    workflow_type: str
     url: str
     status: WorkflowStatus
     tenant_id: str
@@ -34,6 +35,7 @@ class Workflow(SQLModel, table=True):
         """Convert workflow to a dictionary representation."""
         return {
             "public_id": self.public_id,
+            "workflow_type": self.workflow_type,
             "status": self.status,
             "url": self.url,
             "tenant_id": self.tenant_id,

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -26,7 +26,7 @@ class Workflow(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
     public_id: str = Field(default_factory=nanoid)
     workflow_type: str
-    url: str
+    params: dict = Field(default_factory=dict, sa_column=Column(JSON))
     status: WorkflowStatus
     tenant_id: str
     result: dict | None = Field(default=None, sa_column=Column(JSON))
@@ -37,7 +37,7 @@ class Workflow(SQLModel, table=True):
             "public_id": self.public_id,
             "workflow_type": self.workflow_type,
             "status": self.status,
-            "url": self.url,
+            "params": self.params,
             "tenant_id": self.tenant_id,
             "result": self.result,
         }

--- a/app/routers/workflows.py
+++ b/app/routers/workflows.py
@@ -1,10 +1,11 @@
 """Workflow API routes with tenant-scoped access control."""
 
 import asyncio
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import Session, select
 from temporalio.client import Client
@@ -13,7 +14,7 @@ from app.auth import AuthContext, decode_access_token
 from app.database.models import Workflow, WorkflowStatus
 from app.database.session import get_db_session
 from app.dependencies import get_current_user
-from app.workflows.registry import get_workflow_spec
+from app.workflows.registry import WorkflowContext, get_workflow_spec
 
 router = APIRouter(
     prefix="/workflows",
@@ -28,7 +29,7 @@ class CreateWorkflowRequest(BaseModel):
     """Request body for creating a new workflow."""
 
     workflow_type: str
-    params: dict = Field(default_factory=dict)
+    params: dict[str, Any] = Field(default_factory=dict)
 
 
 def _get_temporal_client(request: Request) -> Client:
@@ -87,10 +88,15 @@ async def create(
     except KeyError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
 
+    try:
+        params = spec.params_model.model_validate(body.params)
+    except ValidationError as exc:
+        raise HTTPException(status_code=422, detail=exc.errors()) from exc
+
     workflow = Workflow(
         workflow_type=body.workflow_type,
         status=WorkflowStatus.PROCESSING,
-        url=body.params.get("url", ""),
+        params=params.model_dump(mode="json"),
         tenant_id=auth.tenant_id,
     )
     try:
@@ -102,10 +108,12 @@ async def create(
         raise HTTPException(status_code=500, detail="Could not create workflow")
 
     try:
-        workflow_request = spec.request_class(
-            workflow_id=workflow_id,
-            tenant_id=auth.tenant_id,
-            **body.params,
+        workflow_request = spec.request_builder(
+            WorkflowContext(
+                workflow_id=workflow_id,
+                tenant_id=auth.tenant_id,
+            ),
+            params,
         )
         client = _get_temporal_client(request)
         await client.start_workflow(

--- a/app/routers/workflows.py
+++ b/app/routers/workflows.py
@@ -4,7 +4,7 @@ import asyncio
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import Session, select
 from temporalio.client import Client
@@ -13,10 +13,7 @@ from app.auth import AuthContext, decode_access_token
 from app.database.models import Workflow, WorkflowStatus
 from app.database.session import get_db_session
 from app.dependencies import get_current_user
-from app.workflows.extract_metadata_workflow import (
-    ExtractMetadata,
-    ExtractMetadataWorkflowRequest,
-)
+from app.workflows.registry import get_workflow_spec
 
 router = APIRouter(
     prefix="/workflows",
@@ -30,9 +27,8 @@ STREAM_DELAY = 1
 class CreateWorkflowRequest(BaseModel):
     """Request body for creating a new workflow."""
 
-    url: str
-    extractor: str = "pdfplumber"  # Default to pdfplumber
-    pages: list[int] | None = None  # Page selection
+    workflow_type: str
+    params: dict = Field(default_factory=dict)
 
 
 def _get_temporal_client(request: Request) -> Client:
@@ -85,10 +81,16 @@ async def create(
     auth: AuthContext = Depends(get_current_user),
     session: Session = Depends(get_db_session),
 ):
-    """Create a new workflow and start the Temporal extraction."""
+    """Create a new workflow and start the Temporal workflow."""
+    try:
+        spec = get_workflow_spec(body.workflow_type)
+    except KeyError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
     workflow = Workflow(
+        workflow_type=body.workflow_type,
         status=WorkflowStatus.PROCESSING,
-        url=body.url,
+        url=body.params.get("url", ""),
         tenant_id=auth.tenant_id,
     )
     try:
@@ -100,20 +102,17 @@ async def create(
         raise HTTPException(status_code=500, detail="Could not create workflow")
 
     try:
+        workflow_request = spec.request_class(
+            workflow_id=workflow_id,
+            tenant_id=auth.tenant_id,
+            **body.params,
+        )
         client = _get_temporal_client(request)
         await client.start_workflow(
-            ExtractMetadata.run,
-            args=[
-                ExtractMetadataWorkflowRequest(
-                    workflow_id=workflow_id,
-                    tenant_id=auth.tenant_id,
-                    url=body.url,
-                    extractor=body.extractor,
-                    pages=body.pages,
-                )
-            ],
-            id=f"extract-metadata-{workflow_id}",
-            task_queue="extract-pdf-metadata-task-queue",
+            spec.workflow_fn,
+            args=[workflow_request],
+            id=f"{spec.id_prefix}-{workflow_id}",
+            task_queue=spec.task_queue,
         )
     except Exception as e:
         print("Error(start_temporal_workflow)", e)
@@ -123,7 +122,7 @@ async def create(
         except SQLAlchemyError:
             pass
         raise HTTPException(
-            status_code=500, detail="Could not start extraction workflow"
+            status_code=500, detail="Could not start workflow"
         )
 
     return workflow.to_dict()

--- a/app/routers/workflows.py
+++ b/app/routers/workflows.py
@@ -121,9 +121,7 @@ async def create(
             session.commit()
         except SQLAlchemyError:
             pass
-        raise HTTPException(
-            status_code=500, detail="Could not start workflow"
-        )
+        raise HTTPException(status_code=500, detail="Could not start workflow")
 
     return workflow.to_dict()
 

--- a/app/routers/workflows.py
+++ b/app/routers/workflows.py
@@ -14,7 +14,8 @@ from app.auth import AuthContext, decode_access_token
 from app.database.models import Workflow, WorkflowStatus
 from app.database.session import get_db_session
 from app.dependencies import get_current_user
-from app.workflows.registry import WorkflowContext, get_workflow_spec
+from app.workflows.registry import get_workflow_spec
+from app.workflows.specs import WorkflowContext
 
 router = APIRouter(
     prefix="/workflows",
@@ -111,7 +112,7 @@ async def create(
     try:
         client = _get_temporal_client(request)
         await client.start_workflow(
-            spec.workflow_fn,
+            spec.workflow_cls.run,
             args=[
                 WorkflowContext(
                     workflow_id=workflow_id,

--- a/app/routers/workflows.py
+++ b/app/routers/workflows.py
@@ -99,6 +99,7 @@ async def create(
         params=params.model_dump(mode="json"),
         tenant_id=auth.tenant_id,
     )
+
     try:
         session.add(workflow)
         session.commit()
@@ -108,17 +109,16 @@ async def create(
         raise HTTPException(status_code=500, detail="Could not create workflow")
 
     try:
-        workflow_request = spec.request_builder(
-            WorkflowContext(
-                workflow_id=workflow_id,
-                tenant_id=auth.tenant_id,
-            ),
-            params,
-        )
         client = _get_temporal_client(request)
         await client.start_workflow(
             spec.workflow_fn,
-            args=[workflow_request],
+            args=[
+                WorkflowContext(
+                    workflow_id=workflow_id,
+                    tenant_id=auth.tenant_id,
+                ),
+                params,
+            ],
             id=f"{spec.id_prefix}-{workflow_id}",
             task_queue=spec.task_queue,
         )

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,0 +1,1 @@
+"""Pydantic schemas for the application."""

--- a/app/schemas/metadata_suggestions.py
+++ b/app/schemas/metadata_suggestions.py
@@ -99,7 +99,7 @@ MetadataSuggestion = Annotated[
 ]
 
 
-class MetadataResult(BaseModel):
+class MetadataSuggestions(BaseModel):
     """Container for all metadata suggestions from a workflow run."""
 
     suggestions: list[MetadataSuggestion]

--- a/app/workers.py
+++ b/app/workers.py
@@ -1,42 +1,60 @@
+import argparse
 import asyncio
 
 from pydantic_ai.durable_exec.temporal import PydanticAIPlugin
 from temporalio.client import Client
 from temporalio.worker import Worker
 
-from app.activities import (
-    extract_metadata_with_llm,
-    extract_pdf_text,
-    store_workflow_result,
-)
+from app.activities import REGISTERED_ACTIVITIES
 from app.config import get_settings
 from app.database.session import init_engine
-from app.workflows.extract_metadata_workflow import ExtractMetadata
+from app.workflows.queues import DEFAULT_TASK_QUEUE
+from app.workflows.registry import get_registered_task_queues, get_specs_for_task_queue
+from app.workflows.specs import WorkflowSpec
 
 
-async def main():
+async def _run_worker(
+    client: Client, task_queue: str, specs: list[WorkflowSpec]
+) -> None:
+    worker = Worker(
+        client,
+        task_queue=task_queue,
+        workflows=[spec.workflow_cls for spec in specs],
+        activities=REGISTERED_ACTIVITIES,
+    )
+    await worker.run()
+
+
+async def main(task_queue: str | None = None):
     """Start the Temporal worker."""
     init_engine()
     settings = get_settings()
+    task_queue = task_queue or DEFAULT_TASK_QUEUE
+    workflow_specs = get_specs_for_task_queue(task_queue)
+    if not workflow_specs:
+        registered = ", ".join(get_registered_task_queues()) or "(none)"
+        raise ValueError(
+            f"No workflows registered for task queue {task_queue!r}. "
+            f"Registered task queues: {registered}"
+        )
+
     client = await Client.connect(
         settings.temporal_host,
         plugins=[PydanticAIPlugin()],
     )
 
-    worker = Worker(
-        client,
-        task_queue="extract-pdf-metadata-task-queue",
-        workflows=[
-            ExtractMetadata,
-        ],
-        activities=[
-            extract_pdf_text,  # Activity for extracting all text from the PDF
-            extract_metadata_with_llm,  # Activity for extracting metadata via LLM
-            store_workflow_result,  # Activity to persist status/results
-        ],
+    await _run_worker(client, task_queue, workflow_specs)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Start a Temporal worker.")
+    parser.add_argument(
+        "--task-queue",
+        help="Task queue this worker process should poll.",
     )
-    await worker.run()
+    return parser.parse_args()
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    args = _parse_args()
+    asyncio.run(main(args.task_queue))

--- a/app/workflows/__init__.py
+++ b/app/workflows/__init__.py
@@ -1,0 +1,5 @@
+"""Workflow definitions — importing submodules triggers self-registration."""
+
+# Import workflow modules so their register_workflow() calls execute.
+# To add a new workflow type, add an import here.
+import app.workflows.extract_metadata_workflow  # noqa: F401

--- a/app/workflows/__init__.py
+++ b/app/workflows/__init__.py
@@ -1,5 +1,1 @@
-"""Workflow definitions — importing submodules triggers self-registration."""
-
-# Import workflow modules so their register_workflow() calls execute.
-# To add a new workflow type, add an import here.
-import app.workflows.extract_metadata_workflow  # noqa: F401
+"""Workflow definitions and explicit registry."""

--- a/app/workflows/extract_metadata_workflow.py
+++ b/app/workflows/extract_metadata_workflow.py
@@ -82,3 +82,18 @@ class ExtractMetadata(PydanticAIWorkflow):
         )
 
         return result
+
+
+# Self-register so the API router can dispatch this workflow by name.
+from app.workflows.registry import WorkflowSpec, register_workflow
+
+register_workflow(
+    "extract_metadata",
+    WorkflowSpec(
+        workflow_fn=ExtractMetadata.run,
+        request_class=ExtractMetadataWorkflowRequest,
+        task_queue="extract-pdf-metadata-task-queue",
+        id_prefix="extract-metadata",
+        param_fields=("url", "extractor", "pages"),
+    ),
+)

--- a/app/workflows/extract_metadata_workflow.py
+++ b/app/workflows/extract_metadata_workflow.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl
 from pydantic_ai.durable_exec.temporal import (
     PydanticAIWorkflow,
 )
@@ -20,7 +20,21 @@ from app.activities.store_workflow_result import (
 )
 from app.database.models import WorkflowStatus
 from app.schemas.metadata_suggestions import MetadataSuggestions
-from app.workflows.registry import WorkflowSpec, register_workflow
+from app.workflows.registry import (
+    WorkflowContext,
+    WorkflowSpec,
+    register_workflow,
+)
+
+
+class ExtractMetadataParams(BaseModel):
+    """User-provided params for the extract_metadata workflow."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    url: HttpUrl
+    extractor: str = "pdfplumber"
+    pages: list[int] | None = Field(default_factory=lambda: [1, 2])
 
 
 class ExtractMetadataWorkflowRequest(BaseModel):
@@ -30,7 +44,24 @@ class ExtractMetadataWorkflowRequest(BaseModel):
     tenant_id: str = Field(description="Tenant id (ownership check)")
     url: str
     extractor: str = "pdfplumber"
-    pages: list[int] | None = [1, 2]
+    pages: list[int] | None = Field(default_factory=lambda: [1, 2])
+
+
+def build_extract_metadata_request(
+    context: WorkflowContext,
+    params: BaseModel,
+) -> ExtractMetadataWorkflowRequest:
+    """Combine validated workflow params with server-generated context."""
+    if not isinstance(params, ExtractMetadataParams):
+        raise TypeError("Expected ExtractMetadataParams")
+
+    return ExtractMetadataWorkflowRequest(
+        workflow_id=context.workflow_id,
+        tenant_id=context.tenant_id,
+        url=str(params.url),
+        extractor=params.extractor,
+        pages=params.pages,
+    )
 
 
 @workflow.defn
@@ -89,9 +120,9 @@ register_workflow(
     "extract_metadata",
     WorkflowSpec(
         workflow_fn=ExtractMetadata.run,
-        request_class=ExtractMetadataWorkflowRequest,
+        params_model=ExtractMetadataParams,
+        request_builder=build_extract_metadata_request,
         task_queue="extract-pdf-metadata-task-queue",
         id_prefix="extract-metadata",
-        param_fields=("url", "extractor", "pages"),
     ),
 )

--- a/app/workflows/extract_metadata_workflow.py
+++ b/app/workflows/extract_metadata_workflow.py
@@ -19,7 +19,8 @@ from app.activities.store_workflow_result import (
     store_workflow_result,
 )
 from app.database.models import WorkflowStatus
-from app.workflows.suggestions import MetadataResult
+from app.schemas.metadata_suggestions import MetadataSuggestions
+from app.workflows.registry import WorkflowSpec, register_workflow
 
 
 class ExtractMetadataWorkflowRequest(BaseModel):
@@ -29,7 +30,7 @@ class ExtractMetadataWorkflowRequest(BaseModel):
     tenant_id: str = Field(description="Tenant id (ownership check)")
     url: str
     extractor: str = "pdfplumber"
-    pages: list[int] | None = None
+    pages: list[int] | None = [1, 2]
 
 
 @workflow.defn
@@ -37,7 +38,7 @@ class ExtractMetadata(PydanticAIWorkflow):
     """Workflow that extracts content from a PDF and uses an LLM to extract metadata."""
 
     @workflow.run
-    async def run(self, request: ExtractMetadataWorkflowRequest) -> MetadataResult:
+    async def run(self, request: ExtractMetadataWorkflowRequest) -> MetadataSuggestions:
         """Execute the extraction + suggestions workflow."""
         try:
             # Activity 1: Extract PDF text
@@ -83,9 +84,6 @@ class ExtractMetadata(PydanticAIWorkflow):
 
         return result
 
-
-# Self-register so the API router can dispatch this workflow by name.
-from app.workflows.registry import WorkflowSpec, register_workflow
 
 register_workflow(
     "extract_metadata",

--- a/app/workflows/extract_metadata_workflow.py
+++ b/app/workflows/extract_metadata_workflow.py
@@ -20,11 +20,9 @@ from app.activities.store_workflow_result import (
 )
 from app.database.models import WorkflowStatus
 from app.schemas.metadata_suggestions import MetadataSuggestions
-from app.workflows.registry import (
+from app.workflows.specs import (
     WorkflowContext,
     WorkflowParams,
-    WorkflowSpec,
-    register_workflow,
 )
 
 
@@ -90,14 +88,3 @@ class ExtractMetadata(PydanticAIWorkflow):
         )
 
         return result
-
-
-register_workflow(
-    "extract_metadata",
-    WorkflowSpec(
-        workflow_fn=ExtractMetadata.run,
-        params_model=ExtractMetadataParams,
-        task_queue="extract-pdf-metadata-task-queue",
-        id_prefix="extract-metadata",
-    ),
-)

--- a/app/workflows/extract_metadata_workflow.py
+++ b/app/workflows/extract_metadata_workflow.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 
-from pydantic import BaseModel, ConfigDict, Field, HttpUrl
+from pydantic import Field, HttpUrl
 from pydantic_ai.durable_exec.temporal import (
     PydanticAIWorkflow,
 )
@@ -22,46 +22,18 @@ from app.database.models import WorkflowStatus
 from app.schemas.metadata_suggestions import MetadataSuggestions
 from app.workflows.registry import (
     WorkflowContext,
+    WorkflowParams,
     WorkflowSpec,
     register_workflow,
 )
 
 
-class ExtractMetadataParams(BaseModel):
+class ExtractMetadataParams(WorkflowParams):
     """User-provided params for the extract_metadata workflow."""
-
-    model_config = ConfigDict(extra="forbid")
 
     url: HttpUrl
     extractor: str = "pdfplumber"
     pages: list[int] | None = Field(default_factory=lambda: [1, 2])
-
-
-class ExtractMetadataWorkflowRequest(BaseModel):
-    """Workflow request to extract PDF content and generate metadata suggestions."""
-
-    workflow_id: str = Field(description="Workflow public_id (DB primary identifier)")
-    tenant_id: str = Field(description="Tenant id (ownership check)")
-    url: str
-    extractor: str = "pdfplumber"
-    pages: list[int] | None = Field(default_factory=lambda: [1, 2])
-
-
-def build_extract_metadata_request(
-    context: WorkflowContext,
-    params: BaseModel,
-) -> ExtractMetadataWorkflowRequest:
-    """Combine validated workflow params with server-generated context."""
-    if not isinstance(params, ExtractMetadataParams):
-        raise TypeError("Expected ExtractMetadataParams")
-
-    return ExtractMetadataWorkflowRequest(
-        workflow_id=context.workflow_id,
-        tenant_id=context.tenant_id,
-        url=str(params.url),
-        extractor=params.extractor,
-        pages=params.pages,
-    )
 
 
 @workflow.defn
@@ -69,16 +41,20 @@ class ExtractMetadata(PydanticAIWorkflow):
     """Workflow that extracts content from a PDF and uses an LLM to extract metadata."""
 
     @workflow.run
-    async def run(self, request: ExtractMetadataWorkflowRequest) -> MetadataSuggestions:
+    async def run(
+        self,
+        context: WorkflowContext,
+        params: ExtractMetadataParams,
+    ) -> MetadataSuggestions:
         """Execute the extraction + suggestions workflow."""
         try:
             # Activity 1: Extract PDF text
             content = await workflow.execute_activity(
                 extract_pdf_text,
                 ExtractPdfContentRequest(
-                    url=request.url,
-                    extractor=request.extractor,
-                    pages=request.pages,
+                    url=str(params.url),
+                    extractor=params.extractor,
+                    pages=params.pages,
                 ),
                 start_to_close_timeout=timedelta(minutes=5),
             )
@@ -93,8 +69,8 @@ class ExtractMetadata(PydanticAIWorkflow):
             await workflow.execute_activity(
                 store_workflow_result,
                 WorkflowResultInput(
-                    workflow_id=request.workflow_id,
-                    tenant_id=request.tenant_id,
+                    workflow_id=context.workflow_id,
+                    tenant_id=context.tenant_id,
                     status=WorkflowStatus.ERROR,
                     result=None,
                 ),
@@ -105,8 +81,8 @@ class ExtractMetadata(PydanticAIWorkflow):
         await workflow.execute_activity(
             store_workflow_result,
             WorkflowResultInput(
-                workflow_id=request.workflow_id,
-                tenant_id=request.tenant_id,
+                workflow_id=context.workflow_id,
+                tenant_id=context.tenant_id,
                 status=WorkflowStatus.SUCCESS,
                 result=result.model_dump(),
             ),
@@ -121,7 +97,6 @@ register_workflow(
     WorkflowSpec(
         workflow_fn=ExtractMetadata.run,
         params_model=ExtractMetadataParams,
-        request_builder=build_extract_metadata_request,
         task_queue="extract-pdf-metadata-task-queue",
         id_prefix="extract-metadata",
     ),

--- a/app/workflows/queues.py
+++ b/app/workflows/queues.py
@@ -1,0 +1,3 @@
+"""Workflow task queue names."""
+
+DEFAULT_TASK_QUEUE = "default"

--- a/app/workflows/registry.py
+++ b/app/workflows/registry.py
@@ -1,0 +1,63 @@
+"""Workflow registry — maps workflow type names to Temporal dispatch details."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from pydantic import BaseModel
+
+
+@dataclass(frozen=True)
+class WorkflowSpec:
+    """Describes a Temporal workflow that the API can dispatch."""
+
+    workflow_fn: Any
+    """The ``@workflow.defn`` class's entry-point method (e.g. ``ExtractMetadata.run``)."""
+
+    request_class: type[BaseModel]
+    """Pydantic model used to validate workflow-specific parameters."""
+
+    task_queue: str
+    """Temporal task queue that workers listen on for this workflow."""
+
+    id_prefix: str
+    """Prefix used when constructing the Temporal workflow ID."""
+
+    param_fields: tuple[str, ...] = field(default_factory=tuple)
+    """Fields from the API ``params`` dict that are forwarded to *request_class*."""
+
+
+# Global registry — populated at import time by each workflow module.
+WORKFLOW_REGISTRY: dict[str, WorkflowSpec] = {}
+
+
+def register_workflow(name: str, spec: WorkflowSpec) -> None:
+    """Register a workflow type.
+
+    Raises:
+        ValueError: If *name* is already registered.
+    """
+    if name in WORKFLOW_REGISTRY:
+        raise ValueError(f"Workflow type {name!r} is already registered")
+    WORKFLOW_REGISTRY[name] = spec
+
+
+def get_workflow_spec(name: str) -> WorkflowSpec:
+    """Look up a registered workflow by type name.
+
+    Raises:
+        KeyError: If *name* has not been registered.
+    """
+    try:
+        return WORKFLOW_REGISTRY[name]
+    except KeyError:
+        registered = ", ".join(sorted(WORKFLOW_REGISTRY)) or "(none)"
+        raise KeyError(
+            f"Unknown workflow type {name!r}. Registered types: {registered}"
+        ) from None
+
+
+def get_registered_types() -> list[str]:
+    """Return a sorted list of all registered workflow type names."""
+    return sorted(WORKFLOW_REGISTRY)

--- a/app/workflows/registry.py
+++ b/app/workflows/registry.py
@@ -13,7 +13,7 @@ class WorkflowSpec:
     """Describes a Temporal workflow that the API can dispatch."""
 
     workflow_fn: Any
-    """The ``@workflow.defn`` class's entry-point method (e.g. ``ExtractMetadata.run``)."""
+    """Entry-point method of the ``@workflow.defn`` class."""
 
     request_class: type[BaseModel]
     """Pydantic model used to validate workflow-specific parameters."""

--- a/app/workflows/registry.py
+++ b/app/workflows/registry.py
@@ -2,10 +2,18 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Any
+from dataclasses import dataclass
+from typing import Any, Callable
 
 from pydantic import BaseModel
+
+
+@dataclass(frozen=True)
+class WorkflowContext:
+    """Server-generated context attached to every workflow invocation."""
+
+    workflow_id: str
+    tenant_id: str
 
 
 @dataclass(frozen=True)
@@ -15,17 +23,17 @@ class WorkflowSpec:
     workflow_fn: Any
     """Entry-point method of the ``@workflow.defn`` class."""
 
-    request_class: type[BaseModel]
-    """Pydantic model used to validate workflow-specific parameters."""
+    params_model: type[BaseModel]
+    """Pydantic model used to validate workflow-specific input params."""
+
+    request_builder: Callable[[WorkflowContext, BaseModel], BaseModel]
+    """Build the internal workflow request from validated params + context."""
 
     task_queue: str
     """Temporal task queue that workers listen on for this workflow."""
 
     id_prefix: str
     """Prefix used when constructing the Temporal workflow ID."""
-
-    param_fields: tuple[str, ...] = field(default_factory=tuple)
-    """Fields from the API ``params`` dict that are forwarded to *request_class*."""
 
 
 # Global registry — populated at import time by each workflow module.
@@ -52,7 +60,7 @@ def get_workflow_spec(name: str) -> WorkflowSpec:
     try:
         return WORKFLOW_REGISTRY[name]
     except KeyError:
-        registered = ", ".join(sorted(WORKFLOW_REGISTRY)) or "(none)"
+        registered = ", ".join(get_registered_types()) or "(none)"
         raise KeyError(
             f"Unknown workflow type {name!r}. Registered types: {registered}"
         ) from None

--- a/app/workflows/registry.py
+++ b/app/workflows/registry.py
@@ -1,56 +1,22 @@
-"""Workflow registry — maps workflow type names to Temporal dispatch details."""
+"""Explicit workflow registry."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any
+from app.workflows.extract_metadata_workflow import (
+    ExtractMetadata,
+    ExtractMetadataParams,
+)
+from app.workflows.queues import DEFAULT_TASK_QUEUE
+from app.workflows.specs import WorkflowSpec
 
-from pydantic import BaseModel, ConfigDict
-
-
-class WorkflowContext(BaseModel):
-    """Server-generated context attached to every workflow invocation."""
-
-    workflow_id: str
-    tenant_id: str
-
-
-class WorkflowParams(BaseModel):
-    """Base model for user-provided workflow params."""
-
-    model_config = ConfigDict(extra="forbid")
-
-
-@dataclass(frozen=True)
-class WorkflowSpec:
-    """Describes a Temporal workflow that the API can dispatch."""
-
-    workflow_fn: Any
-    """Entry-point method of the ``@workflow.defn`` class."""
-
-    params_model: type[WorkflowParams]
-    """Pydantic model used to validate workflow-specific input params."""
-
-    task_queue: str
-    """Temporal task queue that workers listen on for this workflow."""
-
-    id_prefix: str
-    """Prefix used when constructing the Temporal workflow ID."""
-
-
-# Global registry — populated at import time by each workflow module.
-WORKFLOW_REGISTRY: dict[str, WorkflowSpec] = {}
-
-
-def register_workflow(name: str, spec: WorkflowSpec) -> None:
-    """Register a workflow type.
-
-    Raises:
-        ValueError: If *name* is already registered.
-    """
-    if name in WORKFLOW_REGISTRY:
-        raise ValueError(f"Workflow type {name!r} is already registered")
-    WORKFLOW_REGISTRY[name] = spec
+WORKFLOW_REGISTRY: dict[str, WorkflowSpec] = {
+    "extract_metadata": WorkflowSpec(
+        workflow_cls=ExtractMetadata,
+        params_model=ExtractMetadataParams,
+        task_queue=DEFAULT_TASK_QUEUE,
+        id_prefix="extract-metadata",
+    ),
+}
 
 
 def get_workflow_spec(name: str) -> WorkflowSpec:
@@ -71,3 +37,18 @@ def get_workflow_spec(name: str) -> WorkflowSpec:
 def get_registered_types() -> list[str]:
     """Return a sorted list of all registered workflow type names."""
     return sorted(WORKFLOW_REGISTRY)
+
+
+def get_registered_specs() -> list[WorkflowSpec]:
+    """Return registered workflow specs sorted by workflow type."""
+    return [WORKFLOW_REGISTRY[name] for name in get_registered_types()]
+
+
+def get_specs_for_task_queue(task_queue: str) -> list[WorkflowSpec]:
+    """Return registered workflow specs served by a task queue."""
+    return [spec for spec in get_registered_specs() if spec.task_queue == task_queue]
+
+
+def get_registered_task_queues() -> list[str]:
+    """Return task queues referenced by registered workflow specs."""
+    return sorted({spec.task_queue for spec in WORKFLOW_REGISTRY.values()})

--- a/app/workflows/registry.py
+++ b/app/workflows/registry.py
@@ -3,17 +3,22 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
-@dataclass(frozen=True)
-class WorkflowContext:
+class WorkflowContext(BaseModel):
     """Server-generated context attached to every workflow invocation."""
 
     workflow_id: str
     tenant_id: str
+
+
+class WorkflowParams(BaseModel):
+    """Base model for user-provided workflow params."""
+
+    model_config = ConfigDict(extra="forbid")
 
 
 @dataclass(frozen=True)
@@ -23,11 +28,8 @@ class WorkflowSpec:
     workflow_fn: Any
     """Entry-point method of the ``@workflow.defn`` class."""
 
-    params_model: type[BaseModel]
+    params_model: type[WorkflowParams]
     """Pydantic model used to validate workflow-specific input params."""
-
-    request_builder: Callable[[WorkflowContext, BaseModel], BaseModel]
-    """Build the internal workflow request from validated params + context."""
 
     task_queue: str
     """Temporal task queue that workers listen on for this workflow."""

--- a/app/workflows/specs.py
+++ b/app/workflows/specs.py
@@ -1,0 +1,38 @@
+"""Shared workflow dispatch types."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class WorkflowContext(BaseModel):
+    """Server-generated context attached to every workflow invocation."""
+
+    workflow_id: str
+    tenant_id: str
+
+
+class WorkflowParams(BaseModel):
+    """Base model for user-provided workflow params."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+@dataclass(frozen=True)
+class WorkflowSpec:
+    """Describes a Temporal workflow that the API can dispatch."""
+
+    workflow_cls: Any
+    """Class decorated with ``@workflow.defn``."""
+
+    params_model: type[WorkflowParams]
+    """Pydantic model used to validate workflow-specific input params."""
+
+    task_queue: str
+    """Temporal task queue that workers listen on for this workflow."""
+
+    id_prefix: str
+    """Prefix used when constructing the Temporal workflow ID."""

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -7,6 +7,7 @@ import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from fastapi.testclient import TestClient
+from sqlmodel import select
 
 from app.config import get_settings
 from app.database.models import Workflow, WorkflowStatus
@@ -198,7 +199,7 @@ def test_workflow_scoped_access_granted(client, db_session):
     wf = Workflow(
         workflow_type="extract_metadata",
         status=WorkflowStatus.SUCCESS,
-        url="https://example.com/test_a.pdf",
+        params={"url": "https://example.com/test_a.pdf"},
         tenant_id="tenant-a",
     )
     db_session.add(wf)
@@ -232,7 +233,7 @@ def test_workflow_admin_access_granted(client, db_session):
     wf = Workflow(
         workflow_type="extract_metadata",
         status=WorkflowStatus.SUCCESS,
-        url="https://example.com/test_a.pdf",
+        params={"url": "https://example.com/test_a.pdf"},
         tenant_id="tenant-a",
     )
     db_session.add(wf)
@@ -259,7 +260,7 @@ def test_tenant_cannot_access_other_tenants_workflow(client, db_session):
     wf = Workflow(
         workflow_type="extract_metadata",
         status=WorkflowStatus.SUCCESS,
-        url="https://example.com/test_a.pdf",
+        params={"url": "https://example.com/test_a.pdf"},
         tenant_id="tenant-a",
     )
     db_session.add(wf)
@@ -391,7 +392,7 @@ def test_stream_cross_tenant_returns_403(client, db_session):
     wf = Workflow(
         workflow_type="extract_metadata",
         status=WorkflowStatus.SUCCESS,
-        url="https://example.com/test_a.pdf",
+        params={"url": "https://example.com/test_a.pdf"},
         tenant_id="tenant-a",
     )
     db_session.add(wf)
@@ -409,7 +410,7 @@ def test_stream_valid_token_returns_200(client, db_session):
     wf = Workflow(
         workflow_type="extract_metadata",
         status=WorkflowStatus.SUCCESS,
-        url="https://example.com/test_a.pdf",
+        params={"url": "https://example.com/test_a.pdf"},
         tenant_id="tenant-a",
     )
     db_session.add(wf)
@@ -462,7 +463,63 @@ def test_create_workflow_stamps_tenant_id(client, db_session, mocker):
     assert wf is not None
     assert wf.tenant_id == "tenant-a"
     assert wf.workflow_type == "extract_metadata"
+    assert wf.params == {
+        "url": "https://example.com/doc.pdf",
+        "extractor": "pdfplumber",
+        "pages": [1, 2],
+    }
     assert wf.public_id == created_id
+
+    mock_temporal.start_workflow.assert_awaited_once()
+    workflow_request = mock_temporal.start_workflow.await_args.kwargs["args"][0]
+    assert workflow_request.workflow_id == created_id
+    assert workflow_request.tenant_id == "tenant-a"
+    assert workflow_request.url == "https://example.com/doc.pdf"
+
+
+def test_create_workflow_rejects_invalid_params(client, db_session, mocker):
+    """POST /workflows/ returns 422 when workflow-specific params are invalid."""
+    token = generate_test_token()
+
+    mock_temporal = mocker.AsyncMock()
+    mocker.patch.object(client.app.state, "temporal_client", mock_temporal)
+
+    response = client.post(
+        "/workflows/",
+        json={
+            "workflow_type": "extract_metadata",
+            "params": {"extractor": "pdfplumber"},
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 422
+    assert db_session.exec(select(Workflow)).all() == []
+    mock_temporal.start_workflow.assert_not_awaited()
+
+
+def test_create_workflow_rejects_unknown_params(client, db_session, mocker):
+    """POST /workflows/ returns 422 when extra workflow-specific params are present."""
+    token = generate_test_token()
+
+    mock_temporal = mocker.AsyncMock()
+    mocker.patch.object(client.app.state, "temporal_client", mock_temporal)
+
+    response = client.post(
+        "/workflows/",
+        json={
+            "workflow_type": "extract_metadata",
+            "params": {
+                "url": "https://example.com/doc.pdf",
+                "surprise": "value",
+            },
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 422
+    assert db_session.exec(select(Workflow)).all() == []
+    mock_temporal.start_workflow.assert_not_awaited()
 
 
 def test_list_workflows_requires_auth(client):
@@ -477,13 +534,13 @@ def test_list_workflows_tenant_isolation(client, db_session):
     wf_a = Workflow(
         workflow_type="extract_metadata",
         status=WorkflowStatus.SUCCESS,
-        url="https://example.com/test_a.pdf",
+        params={"url": "https://example.com/test_a.pdf"},
         tenant_id="tenant-a",
     )
     wf_b = Workflow(
         workflow_type="extract_metadata",
         status=WorkflowStatus.SUCCESS,
-        url="https://example.com/test_b.pdf",
+        params={"url": "https://example.com/test_b.pdf"},
         tenant_id="tenant-b",
     )
     db_session.add_all([wf_a, wf_b])
@@ -523,7 +580,7 @@ def test_read_workflow_includes_result(client, db_session):
     wf = Workflow(
         workflow_type="extract_metadata",
         status=WorkflowStatus.SUCCESS,
-        url="https://example.com/test.pdf",
+        params={"url": "https://example.com/test.pdf"},
         tenant_id="tenant-a",
         result={"suggestions": [{"field": "title", "value": "My Title"}]},
     )
@@ -538,5 +595,6 @@ def test_read_workflow_includes_result(client, db_session):
     )
     assert response.status_code == 200
     payload = response.json()
+    assert payload["params"]["url"] == "https://example.com/test.pdf"
     assert "result" in payload
     assert payload["result"]["suggestions"][0]["field"] == "title"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -196,6 +196,7 @@ def test_auth_disabled_bypass(client, monkeypatch):
 def test_workflow_scoped_access_granted(client, db_session):
     """A token with a matching workflow_id is permitted."""
     wf = Workflow(
+        workflow_type="extract_metadata",
         status=WorkflowStatus.SUCCESS,
         url="https://example.com/test_a.pdf",
         tenant_id="tenant-a",
@@ -229,6 +230,7 @@ def test_workflow_scoped_access_denied(client):
 def test_workflow_admin_access_granted(client, db_session):
     """A token with no workflow_id or workflow_id='*' is permitted."""
     wf = Workflow(
+        workflow_type="extract_metadata",
         status=WorkflowStatus.SUCCESS,
         url="https://example.com/test_a.pdf",
         tenant_id="tenant-a",
@@ -255,6 +257,7 @@ def test_workflow_admin_access_granted(client, db_session):
 def test_tenant_cannot_access_other_tenants_workflow(client, db_session):
     """Tenant B cannot access a workflow owned by tenant A."""
     wf = Workflow(
+        workflow_type="extract_metadata",
         status=WorkflowStatus.SUCCESS,
         url="https://example.com/test_a.pdf",
         tenant_id="tenant-a",
@@ -386,6 +389,7 @@ def test_stream_workflow_scope_mismatch_returns_403(client):
 def test_stream_cross_tenant_returns_403(client, db_session):
     """Tenant B cannot stream a workflow owned by tenant A."""
     wf = Workflow(
+        workflow_type="extract_metadata",
         status=WorkflowStatus.SUCCESS,
         url="https://example.com/test_a.pdf",
         tenant_id="tenant-a",
@@ -403,6 +407,7 @@ def test_stream_cross_tenant_returns_403(client, db_session):
 def test_stream_valid_token_returns_200(client, db_session):
     """A valid token for the owning tenant streams successfully."""
     wf = Workflow(
+        workflow_type="extract_metadata",
         status=WorkflowStatus.SUCCESS,
         url="https://example.com/test_a.pdf",
         tenant_id="tenant-a",
@@ -423,7 +428,13 @@ def test_stream_valid_token_returns_200(client, db_session):
 
 def test_create_workflow_requires_auth(client):
     """POST /workflows/ without a token is rejected."""
-    response = client.post("/workflows/", json={"url": "https://example.com/doc.pdf"})
+    response = client.post(
+        "/workflows/",
+        json={
+            "workflow_type": "extract_metadata",
+            "params": {"url": "https://example.com/doc.pdf"},
+        },
+    )
     assert response.status_code == 401
 
 
@@ -437,7 +448,10 @@ def test_create_workflow_stamps_tenant_id(client, db_session, mocker):
 
     response = client.post(
         "/workflows/",
-        json={"url": "https://example.com/doc.pdf"},
+        json={
+            "workflow_type": "extract_metadata",
+            "params": {"url": "https://example.com/doc.pdf"},
+        },
         headers={"Authorization": f"Bearer {token}"},
     )
     assert response.status_code == 200
@@ -447,6 +461,7 @@ def test_create_workflow_stamps_tenant_id(client, db_session, mocker):
     wf = db_session.get(Workflow, 1)
     assert wf is not None
     assert wf.tenant_id == "tenant-a"
+    assert wf.workflow_type == "extract_metadata"
     assert wf.public_id == created_id
 
 
@@ -460,11 +475,13 @@ def test_list_workflows_tenant_isolation(client, db_session):
     """GET /workflows/ only returns workflows for the authenticated tenant."""
     # Create workflows for two different tenants
     wf_a = Workflow(
+        workflow_type="extract_metadata",
         status=WorkflowStatus.SUCCESS,
         url="https://example.com/test_a.pdf",
         tenant_id="tenant-a",
     )
     wf_b = Workflow(
+        workflow_type="extract_metadata",
         status=WorkflowStatus.SUCCESS,
         url="https://example.com/test_b.pdf",
         tenant_id="tenant-b",
@@ -504,6 +521,7 @@ def test_list_workflows_tenant_isolation(client, db_session):
 def test_read_workflow_includes_result(client, db_session):
     """GET /workflows/{id} includes `result.suggestions` when present."""
     wf = Workflow(
+        workflow_type="extract_metadata",
         status=WorkflowStatus.SUCCESS,
         url="https://example.com/test.pdf",
         tenant_id="tenant-a",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -471,10 +471,12 @@ def test_create_workflow_stamps_tenant_id(client, db_session, mocker):
     assert wf.public_id == created_id
 
     mock_temporal.start_workflow.assert_awaited_once()
-    workflow_request = mock_temporal.start_workflow.await_args.kwargs["args"][0]
-    assert workflow_request.workflow_id == created_id
-    assert workflow_request.tenant_id == "tenant-a"
-    assert workflow_request.url == "https://example.com/doc.pdf"
+    workflow_context, workflow_params = mock_temporal.start_workflow.await_args.kwargs[
+        "args"
+    ]
+    assert workflow_context.workflow_id == created_id
+    assert workflow_context.tenant_id == "tenant-a"
+    assert str(workflow_params.url) == "https://example.com/doc.pdf"
 
 
 def test_create_workflow_rejects_invalid_params(client, db_session, mocker):


### PR DESCRIPTION
This PR is to refactor a few things:

1. Support multiple workflows, which we register on application start.
2. Param validation for each workflow. We use a workflow "builder" for the request.

Following the PR, I'll create a separate PR to integrate `ty`, since it's time to be a bit stricter with types.
