### PR TITLE
fix: activites: explicit raise if page selection not valid

### DIFF
--- a/app/activities/extract_pdf_content.py
+++ b/app/activities/extract_pdf_content.py
@@ -4,6 +4,7 @@ from temporalio import activity
 from temporalio.exceptions import ApplicationError
 
 from app.extractors import get_extractor
+from app.extractors.errors import InvalidPageSelectionError
 
 
 class ExtractPdfContentRequest(BaseModel):
@@ -44,7 +45,14 @@ async def extract_pdf_text(
             non_retryable=True,
         ) from e
 
-    result = extractor.extract(pdf_bytes, request.pages)
+    try:
+        result = extractor.extract(pdf_bytes, request.pages)
+    except InvalidPageSelectionError as e:
+        raise ApplicationError(
+            str(e),
+            type="InvalidPageSelection",
+            non_retryable=True,
+        ) from e
 
     return ExtractPdfContentResponse(
         text=result["full_text"],

--- a/app/extractors/errors.py
+++ b/app/extractors/errors.py
@@ -1,0 +1,5 @@
+"""Custom exceptions for PDF extractors."""
+
+
+class InvalidPageSelectionError(ValueError):
+    """Raised when a requested page selection is invalid for a PDF."""

--- a/app/extractors/utils.py
+++ b/app/extractors/utils.py
@@ -2,13 +2,36 @@
 
 from typing import List, Optional
 
+from .errors import InvalidPageSelectionError
+
 
 def resolve_pages(pages: Optional[List[int]], total_pages: int) -> Optional[List[int]]:
     """Resolve page list with negative indices to 0-based page numbers."""
     if pages is None:
         return None
+
+    if total_pages < 1:
+        raise InvalidPageSelectionError("Cannot select pages from a PDF with no pages")
+
     resolved = set()
     for p in pages:
-        idx = p % total_pages if p < 0 else p - 1
+        if p == 0:
+            raise InvalidPageSelectionError(
+                "Page numbers are 1-based; 0 is not allowed"
+            )
+
+        if p > 0:
+            if p > total_pages:
+                raise InvalidPageSelectionError(
+                    f"Page {p} is out of range for a PDF with {total_pages} pages"
+                )
+            idx = p - 1
+        else:
+            if p < -total_pages:
+                raise InvalidPageSelectionError(
+                    f"Page {p} is out of range for a PDF with {total_pages} pages"
+                )
+            idx = total_pages + p
+
         resolved.add(idx)
     return sorted(resolved)


### PR DESCRIPTION
closes #17 

I think this is a good enough pattern. We only support: [-max_page,max_page] - {0}

I'll document this in the first release docs.