### PR TITLE
fix(helm): remove appVersion

### DIFF
--- a/charts/orcha/Chart.yaml
+++ b/charts/orcha/Chart.yaml
@@ -3,7 +3,6 @@ name: orcha
 description: A Helm chart for Orcha
 type: application
 version: 0.1.0
-appVersion: "0.0.2"
 
 dependencies:
   - name: temporal

--- a/charts/orcha/templates/deployment-worker.yaml
+++ b/charts/orcha/templates/deployment-worker.yaml
@@ -23,7 +23,7 @@ spec:
       {{- end }}
       containers:
         - name: worker
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with .Values.securityContext }}
           securityContext:

--- a/charts/orcha/values.yaml
+++ b/charts/orcha/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 image:
   repository: orcha
   pullPolicy: IfNotPresent
-  tag: "" # Overrides the image tag whose default is the chart appVersion.
+  tag: "" # Required
 
 serviceAccount:
   create: true


### PR DESCRIPTION
appVersion is an optional, informational field. Instead of editing the file every time the app version is bumped, we remove this field from Chart.yaml. image.tag becomes a required field, making it easier to ensure the deployment uses the desired app version (and matching image version).
