### PR TITLE
revert(helm): restore appVersion in Chart

### DIFF
--- a/charts/orcha/Chart.yaml
+++ b/charts/orcha/Chart.yaml
@@ -3,6 +3,7 @@ name: orcha
 description: A Helm chart for Orcha
 type: application
 version: 0.1.0
+appVersion: "0.1.1"
 
 dependencies:
   - name: temporal

--- a/charts/orcha/templates/deployment-worker.yaml
+++ b/charts/orcha/templates/deployment-worker.yaml
@@ -23,7 +23,7 @@ spec:
       {{- end }}
       containers:
         - name: worker
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with .Values.securityContext }}
           securityContext:

--- a/charts/orcha/values.yaml
+++ b/charts/orcha/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 image:
   repository: orcha
   pullPolicy: IfNotPresent
-  tag: "" # Required
+  tag: "" # Overrides the image tag whose default is the chart appVersion.
 
 serviceAccount:
   create: true


### PR DESCRIPTION
Revert the change in a154571. Preferred approach is to define the app version in the Chart. The version will be automatically used as the image tag for deployment.

