### PR TITLE
Configurable LLM with more reliable extraction

### DIFF
--- a/app/activities/extract_metadata.py
+++ b/app/activities/extract_metadata.py
@@ -4,14 +4,14 @@
 """LLM-based metadata suggestions activity."""
 
 from pydantic import BaseModel, Field
-from pydantic_ai import Agent
-from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai import Agent, PromptedOutput
+from pydantic_ai.models.openai import OpenAIChatModel, OpenAIChatModelSettings
 from pydantic_ai.providers.litellm import LiteLLMProvider
 from pydantic_ai.providers.ollama import OllamaProvider
 from temporalio import activity
 
 from app.config import get_settings
-from app.schemas.metadata_suggestions import MetadataSuggestions
+from app.schemas.metadata_suggestions import ExtractedMetadata, MetadataSuggestions
 
 
 def _parse_llm(llm: str) -> tuple[str, str]:
@@ -33,45 +33,51 @@ class ExtractMetadataRequest(BaseModel):
     text: str = Field(description="Document text to analyze")
 
 
-INSTRUCTIONS = """\
-You generate metadata suggestions from document text.
-
-Return a list of typed suggestions for the following fields:
-- title (string)
-- description (string; the abstract/summary)
-- creators (list of objects with: name, affiliation (optional), orcid (optional))
-- doi (string; the Digital Object Identifier")
-- publication_date (string; ISO 8601, examples:
-    - "2014-07-17" (full date known)
-    - "2014" (only year known)
-    - Input: "17 July 2023" -> Output: "2023-07-17"
-    - Input: "July 2023" -> Output: "2023"
-    - Input: "2023-07" -> Output: "2023")
-
-Rules:
-- Only include information that is clearly stated in the text.
-- If a field is not present or cannot be determined, omit that suggestion entirely.
-- For creators.name, use the "Family, Given" format.
-"""
+INSTRUCTIONS = (
+    "You extract bibliographic metadata from the document text. "
+    "Only include information clearly stated in the text; "
+    "leave anything you cannot determine empty."
+)
 
 
-def _create_model() -> OpenAIChatModel:
-    """Create an OpenAI-compatible chat model from settings."""
+# Extra instruction pieces for prompted output (no native tool calls): cap
+# reasoning, then force a single JSON object.
+_REASONING_LOW = "Reasoning: low"
+_JSON_ONLY = (
+    "Respond immediately; do not deliberate. "
+    "Reply with exactly one JSON object matching the schema and nothing else."
+)
+
+
+def _build_agent(llm: str) -> Agent[None, ExtractedMetadata]:
+    """Build the extraction agent for `llm` from the configured settings."""
     settings = get_settings()
-    provider_name, model_name = _parse_llm(settings.llm)
+    cfg = settings.llm_settings
+    provider_name, model_name = _parse_llm(llm)
 
     if provider_name == "ollama":
         provider = OllamaProvider(
-            base_url=settings.ollama_base_url,
-            api_key=settings.ollama_api_key,
+            base_url=settings.ollama_base_url, api_key=settings.ollama_api_key
         )
     else:
         provider = LiteLLMProvider(
-            api_base=settings.litellm_api_base,
-            api_key=settings.litellm_api_key,
+            api_base=settings.litellm_api_base, api_key=settings.litellm_api_key
         )
 
-    return OpenAIChatModel(model_name=model_name, provider=provider)
+    model = OpenAIChatModel(
+        model_name=model_name,
+        provider=provider,
+        settings=OpenAIChatModelSettings(**cfg.model),
+    )
+    if cfg.output == "prompted":
+        return Agent[None, ExtractedMetadata](
+            model,
+            instructions=[_REASONING_LOW, INSTRUCTIONS, _JSON_ONLY],
+            output_type=PromptedOutput(ExtractedMetadata),
+        )
+    return Agent[None, ExtractedMetadata](
+        model, instructions=INSTRUCTIONS, output_type=ExtractedMetadata
+    )
 
 
 @activity.defn
@@ -79,12 +85,6 @@ async def extract_metadata_with_llm(
     request: ExtractMetadataRequest,
 ) -> MetadataSuggestions:
     """Generate typed metadata suggestions using an LLM."""
-    model = _create_model()
-    agent = Agent[None, MetadataSuggestions](
-        model=model,
-        instructions=INSTRUCTIONS,
-        output_type=MetadataSuggestions,
-    )
-
+    agent = _build_agent(get_settings().llm)
     result = await agent.run(request.text)
-    return result.output
+    return result.output.to_suggestions()

--- a/app/config.py
+++ b/app/config.py
@@ -4,8 +4,24 @@
 """Centralized application settings using Pydantic Settings."""
 
 from functools import lru_cache
+from typing import Any, Literal
 
+from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings
+
+
+class LlmSettings(BaseModel):
+    """Extra LLM config, parsed from the JSON ``LLM_SETTINGS`` env var.
+
+    ``model`` is forwarded verbatim to the chat model's request settings
+    (``max_tokens``, ``extra_body``, ``temperature`` ...). The rest are Orcha
+    signals that decide how the agent is assembled.
+    """
+
+    # Orcha signal: structured-output strategy.
+    output: Literal["tool", "prompted"] = "tool"
+    # Passed straight to OpenAIChatModelSettings.
+    model: dict[str, Any] = Field(default_factory=dict)
 
 
 class Settings(BaseSettings):
@@ -33,6 +49,7 @@ class Settings(BaseSettings):
     # TODO Currently we have only a single workflow, so single LLM configuration
     # is fine. We can parameterize it or make it configurable per workflow later.
     llm: str = "ollama/qwen3:4b"
+    llm_settings: LlmSettings = Field(default_factory=LlmSettings)
     litellm_api_base: str = "<litellm-endpoint>"
     litellm_api_key: str | None = None
     ollama_base_url: str = "http://localhost:11434/v1"

--- a/app/extractors/pdfplumber.py
+++ b/app/extractors/pdfplumber.py
@@ -63,15 +63,10 @@ class PdfplumberExtractor(BaseExtractor):
                                 }
                             )
 
-        # Build full text including table content
+        # Page text already contains table cell text in reading order; the
+        # structured `tables` are returned in `extra` rather than flattened into
+        # `full_text`, which only duplicated content and added empty-cell noise.
         full_text = "\n\n".join(full_text_parts)
-
-        # Add table content to full_text for searchability
-        for table in tables:
-            for row in table["data"]:
-                if row:
-                    row_text = " | ".join(str(cell) if cell else "" for cell in row)
-                    full_text += "\n" + row_text
 
         # Extract ORCID IDs from hyperlinks and add to full_text
         # This makes ORCIDs discoverable even when they're only in link URLs

--- a/app/schemas/metadata_suggestions.py
+++ b/app/schemas/metadata_suggestions.py
@@ -98,3 +98,43 @@ class MetadataSuggestions(BaseModel):
     """Container for all metadata suggestions from a workflow run."""
 
     suggestions: list[MetadataSuggestion]
+
+
+class ExtractedMetadata(BaseModel):
+    """Flat schema the LLM fills; converted to ``MetadataSuggestions``.
+
+    Smaller models handle a flat object far better than the discriminated union.
+    """
+
+    title: str | None = Field(default=None, description="Document title")
+    description: str | None = Field(default=None, description="Abstract or summary")
+    creators: list[Creator] = Field(
+        default_factory=list, description="Authors or creators"
+    )
+    doi: str | None = Field(default=None, description="The Digital Object Identifier")
+    publication_date: str | None = Field(
+        default=None,
+        description=(
+            "Publication date in ISO 8601, at the precision known: 'YYYY-MM-DD', "
+            "'YYYY-MM', or 'YYYY'. Normalize written dates: '17 July 2023' -> "
+            "'2023-07-17', 'July 2023' -> '2023-07', '2023' -> '2023'."
+        ),
+        examples=["2014-07-17", "2014-07", "2014"],
+    )
+
+    def to_suggestions(self) -> MetadataSuggestions:
+        """Build the typed suggestions, dropping null/empty fields."""
+        suggestions: list[MetadataSuggestion] = []
+        if self.title:
+            suggestions.append(TitleSuggestion(value=self.title))
+        if self.description:
+            suggestions.append(DescriptionSuggestion(value=self.description))
+        if self.creators:
+            creators = CreatorsSuggestion(value=self.creators)
+            if creators.value:
+                suggestions.append(creators)
+        if self.doi:
+            suggestions.append(DoiSuggestion(value=self.doi))
+        if self.publication_date:
+            suggestions.append(PublicationDateSuggestion(value=self.publication_date))
+        return MetadataSuggestions(suggestions=suggestions)

--- a/app/schemas/metadata_suggestions.py
+++ b/app/schemas/metadata_suggestions.py
@@ -80,16 +80,8 @@ class PublicationDateSuggestion(BaseModel):
     @field_validator("value")
     @classmethod
     def normalize_publication_date(cls, v: str) -> str:
-        """Apply normalization for publication dates."""
-        cleaned = " ".join(v.split()).strip()
-        # Keep existing canonical full dates.
-        if len(cleaned) == 10 and cleaned[4] == "-" and cleaned[7] == "-":
-            return cleaned
-        # Convert YYYY-MM to YYYY.
-        if len(cleaned) == 7 and cleaned[4] == "-":
-            return cleaned[:4]
-        # Keep year-only and unknown formats as-is.
-        return cleaned
+        """Collapse whitespace; ISO 8601 date, year-month, and year are all kept."""
+        return " ".join(v.split()).strip()
 
 
 MetadataSuggestion = Annotated[


### PR DESCRIPTION
- **feat(config): configurable LLM settings via LLM_SETTINGS**
  LlmSettings parses the JSON LLM_SETTINGS env var: `model` forwards to the chat model's request settings, `output` selects the structured-output strategy.
  

- **fix(schema): keep YYYY-MM precision for publication dates**
  The validator collapsed YYYY-MM to YYYY; keep whatever precision is given.
  

- **refactor(extraction): flat LLM schema with configurable output mode**
  Use a flat ExtractedMetadata (converted back to MetadataSuggestions) instead of the discriminated union, which small models handle poorly. Output mode and model settings come from config; field guidance lives in the schema, slimming the instructions.
  

- **fix(extractor): stop flattening tables into full_text**
  Tables were re-appended as pipe-joined rows that duplicated page text and added empty-cell noise, bloating the prompt on dense documents. They remain in `extra`.
  