### PR TITLE
feat(tracing): add langfuse tracing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         run: uv python install 3.14
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --extra langfuse
 
       - name: Check formatting
         run: uv run ruff format --check .
@@ -39,7 +39,7 @@ jobs:
         run: uv python install 3.14
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --extra langfuse
 
       - name: Check types
         run: uv run ty check --output-format github
@@ -56,7 +56,7 @@ jobs:
         run: uv python install 3.14
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --extra langfuse
 
       - name: Run tests
         run: uv run pytest tests/

--- a/app/activities/extract_metadata.py
+++ b/app/activities/extract_metadata.py
@@ -14,7 +14,9 @@ from temporalio import activity
 from temporalio.common import RetryPolicy
 
 from app.config import get_settings
+from app.observability import propagate_langfuse_context
 from app.schemas.metadata_suggestions import ExtractedMetadata, MetadataSuggestions
+from app.workflows.specs import WorkflowContext
 
 EXTRACT_METADATA_RETRY_POLICY = RetryPolicy(
     initial_interval=timedelta(seconds=5),
@@ -93,8 +95,11 @@ def _build_agent(llm: str) -> Agent[None, ExtractedMetadata]:
 @activity.defn
 async def extract_metadata_with_llm(
     request: ExtractMetadataRequest,
+    context: WorkflowContext,
 ) -> MetadataSuggestions:
     """Generate typed metadata suggestions using an LLM."""
     agent = _build_agent(get_settings().llm)
-    result = await agent.run(request.text)
+    with propagate_langfuse_context(context, trace_name="extract_metadata"):
+        result = await agent.run(request.text)
+
     return result.output.to_suggestions()

--- a/app/config.py
+++ b/app/config.py
@@ -55,6 +55,12 @@ class Settings(BaseSettings):
     ollama_base_url: str = "http://localhost:11434/v1"
     ollama_api_key: str | None = None
 
+    # Langfuse
+    langfuse_enabled: bool = False
+    langfuse_public_key: str | None = None
+    langfuse_secret_key: str | None = None
+    langfuse_base_url: str | None = None
+
     @property
     def database_url(self) -> str:
         """Build the PostgreSQL connection string."""

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -33,6 +33,7 @@ class Workflow(SQLModel, table=True):
     params: dict = Field(default_factory=dict, sa_column=Column(JSON))
     status: WorkflowStatus
     tenant_id: str
+    user_id: str | None = None
     result: dict | None = Field(default=None, sa_column=Column(JSON))
     created: datetime = Field(
         default_factory=lambda: datetime.now(UTC),

--- a/app/observability.py
+++ b/app/observability.py
@@ -10,11 +10,12 @@ from app.config import get_settings
 from app.workflows.specs import WorkflowContext
 
 
-def _langfuse_metadata(context: WorkflowContext) -> dict[str, str]:
+def _langfuse_metadata(context: WorkflowContext) -> dict[str, str | None]:
     """Build Langfuse metadata from workflow context."""
     return {
         "workflowId": context.workflow_id,
         "tenantId": context.tenant_id,
+        "userId": context.user_id,
     }
 
 
@@ -32,7 +33,7 @@ def propagate_langfuse_context(
     from langfuse import propagate_attributes
 
     with propagate_attributes(
-        user_id=context.tenant_id,
+        user_id=context.user_id or context.tenant_id,
         session_id=context.workflow_id,
         trace_name=trace_name,
         metadata=_langfuse_metadata(context),

--- a/app/observability.py
+++ b/app/observability.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+"""Observability helpers."""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from app.workflows.specs import WorkflowContext
+
+
+def _langfuse_metadata(context: WorkflowContext) -> dict[str, str]:
+    """Build Langfuse metadata from workflow context."""
+    return {
+        "workflowId": context.workflow_id,
+        "tenantId": context.tenant_id,
+    }
+
+
+@contextmanager
+def propagate_langfuse_context(
+    context: WorkflowContext,
+    *,
+    trace_name: str,
+) -> Iterator[None]:
+    """Propagate workflow context to Langfuse at activity runtime."""
+    from langfuse import propagate_attributes
+
+    with propagate_attributes(
+        user_id=context.tenant_id,
+        session_id=context.workflow_id,
+        trace_name=trace_name,
+        metadata=_langfuse_metadata(context),
+    ):
+        yield

--- a/app/observability.py
+++ b/app/observability.py
@@ -6,6 +6,7 @@
 from collections.abc import Iterator
 from contextlib import contextmanager
 
+from app.config import get_settings
 from app.workflows.specs import WorkflowContext
 
 
@@ -24,6 +25,10 @@ def propagate_langfuse_context(
     trace_name: str,
 ) -> Iterator[None]:
     """Propagate workflow context to Langfuse at activity runtime."""
+    if not get_settings().langfuse_enabled:
+        yield
+        return
+
     from langfuse import propagate_attributes
 
     with propagate_attributes(

--- a/app/routers/workflows.py
+++ b/app/routers/workflows.py
@@ -39,6 +39,7 @@ class CreateWorkflowRequest(BaseModel):
 
     workflow_type: str
     params: dict[str, Any] = Field(default_factory=dict)
+    user_id: str | None = None
 
 
 def _get_temporal_client(request: Request) -> Client:
@@ -111,6 +112,7 @@ async def create(
         status=WorkflowStatus.PROCESSING,
         params=params.model_dump(mode="json"),
         tenant_id=auth.tenant_id,
+        user_id=body.user_id,
     )
 
     try:
@@ -129,6 +131,7 @@ async def create(
                 WorkflowContext(
                     workflow_id=workflow_id,
                     tenant_id=auth.tenant_id,
+                    user_id=workflow.user_id,
                 ),
                 params,
             ],

--- a/app/workers.py
+++ b/app/workers.py
@@ -4,7 +4,6 @@
 import argparse
 import asyncio
 
-from langfuse import Langfuse
 from pydantic_ai import Agent
 from pydantic_ai.durable_exec.temporal import PydanticAIPlugin
 from temporalio.client import Client
@@ -31,11 +30,18 @@ async def _run_worker(
     await worker.run()
 
 
-def _configure_langfuse_client(settings: Settings) -> Langfuse | None:
+def _configure_langfuse_client(settings: Settings):
     """Create the Langfuse client when tracing is enabled."""
     if not settings.langfuse_enabled:
         Agent.instrument_all(False)
         return None
+
+    try:
+        from langfuse import Langfuse
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "Langfuse tracing requires the optional 'langfuse' dependency."
+        ) from exc
 
     if not settings.langfuse_public_key or not settings.langfuse_secret_key:
         raise ValueError(

--- a/app/workers.py
+++ b/app/workers.py
@@ -4,13 +4,15 @@
 import argparse
 import asyncio
 
+from langfuse import Langfuse
+from pydantic_ai import Agent
 from pydantic_ai.durable_exec.temporal import PydanticAIPlugin
 from temporalio.client import Client
 from temporalio.contrib.pydantic import pydantic_data_converter
 from temporalio.worker import Worker
 
 from app.activities import REGISTERED_ACTIVITIES
-from app.config import get_settings
+from app.config import Settings, get_settings
 from app.database.session import init_engine
 from app.workflows.queues import DEFAULT_TASK_QUEUE
 from app.workflows.registry import get_registered_task_queues, get_specs_for_task_queue
@@ -29,10 +31,33 @@ async def _run_worker(
     await worker.run()
 
 
+def _configure_langfuse_client(settings: Settings) -> Langfuse | None:
+    """Create the Langfuse client when tracing is enabled."""
+    if not settings.langfuse_enabled:
+        Agent.instrument_all(False)
+        return None
+
+    if not settings.langfuse_public_key or not settings.langfuse_secret_key:
+        raise ValueError(
+            "LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY are required when "
+            "LANGFUSE_ENABLED is true"
+        )
+
+    client = Langfuse(
+        public_key=settings.langfuse_public_key,
+        secret_key=settings.langfuse_secret_key,
+        base_url=settings.langfuse_base_url,
+        tracing_enabled=True,
+    )
+    Agent.instrument_all(True)
+    return client
+
+
 async def main(task_queue: str | None = None):
     """Start the Temporal worker."""
     init_engine()
     settings = get_settings()
+    langfuse_client = _configure_langfuse_client(settings)
     task_queue = task_queue or DEFAULT_TASK_QUEUE
     workflow_specs = get_specs_for_task_queue(task_queue)
     if not workflow_specs:
@@ -48,7 +73,11 @@ async def main(task_queue: str | None = None):
         plugins=[PydanticAIPlugin()],
     )
 
-    await _run_worker(client, task_queue, workflow_specs)
+    try:
+        await _run_worker(client, task_queue, workflow_specs)
+    finally:
+        if langfuse_client is not None:
+            langfuse_client.flush()
 
 
 def _parse_args() -> argparse.Namespace:

--- a/app/workflows/extract_metadata_workflow.py
+++ b/app/workflows/extract_metadata_workflow.py
@@ -78,7 +78,7 @@ class ExtractMetadata(PydanticAIWorkflow):
             # Activity 2: Generate metadata suggestions using LLM
             result = await workflow.execute_activity(
                 extract_metadata_with_llm,
-                ExtractMetadataRequest(text=content.text),
+                args=[ExtractMetadataRequest(text=content.text), context],
                 start_to_close_timeout=timedelta(minutes=5),
                 retry_policy=EXTRACT_METADATA_RETRY_POLICY,
             )

--- a/app/workflows/specs.py
+++ b/app/workflows/specs.py
@@ -16,6 +16,7 @@ class WorkflowContext(BaseModel):
 
     workflow_id: str
     tenant_id: str
+    user_id: str | None = None
 
 
 class WorkflowParams(BaseModel):

--- a/migrations/versions/9f42bf0a8e3d_add_workflow_user_id.py
+++ b/migrations/versions/9f42bf0a8e3d_add_workflow_user_id.py
@@ -1,0 +1,28 @@
+"""add workflow user id.
+
+Revision ID: 9f42bf0a8e3d
+Revises: 465d6f3db028
+Create Date: 2026-07-02 11:30:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "9f42bf0a8e3d"
+down_revision: str | Sequence[str] | None = "465d6f3db028"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Apply this revision."""
+    op.add_column("workflow", sa.Column("user_id", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    """Revert this revision."""
+    op.drop_column("workflow", "user_id")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ dependencies = [
     "fastapi-limiter>=0.2.0",
     "fastapi[standard]>=0.136.1",
     "httpx>=0.28.1",
-    "langfuse>=4.7.0",
     "nanoid>=2.0.0",
     "pdfplumber>=0.11.9",
     "pymupdf>=1.27.2.3",
@@ -29,6 +28,11 @@ dependencies = [
 
 [project.scripts]
 orcha = "app.cli.main:app"
+
+[project.optional-dependencies]
+langfuse = [
+    "langfuse>=4.7.0",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "fastapi-limiter>=0.2.0",
     "fastapi[standard]>=0.136.1",
     "httpx>=0.28.1",
+    "langfuse>=4.7.0",
     "nanoid>=2.0.0",
     "pdfplumber>=0.11.9",
     "pymupdf>=1.27.2.3",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -443,7 +443,7 @@ def test_create_workflow_requires_auth(client):
 
 
 def test_create_workflow_stamps_tenant_id(client, db_session, mocker):
-    """POST /workflows/ stamps the tenant_id from the auth context."""
+    """POST /workflows/ stamps tenant context and request user context."""
     token = generate_test_token()
 
     # Mock the temporal client to avoid real connection
@@ -454,6 +454,7 @@ def test_create_workflow_stamps_tenant_id(client, db_session, mocker):
         "/workflows/",
         json={
             "workflow_type": "extract_metadata",
+            "user_id": "user-123",
             "params": {"url": "https://example.com/doc.pdf"},
         },
         headers={"Authorization": f"Bearer {token}"},
@@ -465,6 +466,7 @@ def test_create_workflow_stamps_tenant_id(client, db_session, mocker):
     wf = db_session.get(Workflow, 1)
     assert wf is not None
     assert wf.tenant_id == "tenant-a"
+    assert wf.user_id == "user-123"
     assert wf.workflow_type == "extract_metadata"
     assert wf.params == {
         "url": "https://example.com/doc.pdf",
@@ -472,6 +474,7 @@ def test_create_workflow_stamps_tenant_id(client, db_session, mocker):
         "pages": [1, 2],
     }
     assert wf.public_id == created_id
+    assert response.json()["user_id"] == "user-123"
 
     mock_temporal.start_workflow.assert_awaited_once()
     workflow_context, workflow_params = mock_temporal.start_workflow.await_args.kwargs[
@@ -479,6 +482,7 @@ def test_create_workflow_stamps_tenant_id(client, db_session, mocker):
     ]
     assert workflow_context.workflow_id == created_id
     assert workflow_context.tenant_id == "tenant-a"
+    assert workflow_context.user_id == "user-123"
     assert str(workflow_params.url) == "https://example.com/doc.pdf"
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -193,6 +193,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
+]
+
+[[package]]
 name = "beartype"
 version = "0.22.9"
 source = { registry = "https://pypi.org/simple" }
@@ -823,7 +832,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/94/5e/a70f31e3e8d961c4ce589c15b28e4225d63704e431a23932a3808cbcc867/greenlet-3.5.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:f35807464c4c58c55f0d31dfa83c541a5615d825c2fe3d2b95360cf7c4e3c0a8", size = 285564, upload-time = "2026-04-27T12:23:08.555Z" },
     { url = "https://files.pythonhosted.org/packages/af/a6/046c0a28e21833e4086918218cfb3d8bed51c075a1b700f20b9d7861c0f4/greenlet-3.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55fa7ea52771be44af0de27d8b80c02cd18c2c3cddde6c847ecebdf72418b6a1", size = 651166, upload-time = "2026-04-27T12:52:43.644Z" },
     { url = "https://files.pythonhosted.org/packages/47/f8/4af27f71c5ff32a7fbc516adb46370d9c4ae2bc7bd3dc7d066ac542b4b15/greenlet-3.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a97e4821aa710603f94de0da25f25096454d78ffdace5dc77f3a006bc01abba3", size = 663792, upload-time = "2026-04-27T12:59:44.93Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/89/2dadb89793c37ee8b4c237857188293e9060dc085f19845c292e00f8e091/greenlet-3.5.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bf2d8a80bec89ab46221ae45c5373d5ba0bd36c19aa8508e85c6cd7e5106cd37", size = 668086, upload-time = "2026-04-27T13:02:42.314Z" },
     { url = "https://files.pythonhosted.org/packages/a3/59/1bd6d7428d6ed9106efbb8c52310c60fd04f6672490f452aeaa3829aa436/greenlet-3.5.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f52a464e4ed91780bdfbbdd2b97197f3accaa629b98c200f4dffada759f3ae7", size = 660933, upload-time = "2026-04-27T12:25:33.276Z" },
+    { url = "https://files.pythonhosted.org/packages/82/35/75722be7e26a2af4cbd2dc35b0ed382dacf9394b7e75551f76ed1abe87f2/greenlet-3.5.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:1bae92a1dd94c5f9d9493c3a212dd874c202442047cf96446412c862feca83a2", size = 470799, upload-time = "2026-04-27T13:05:17.094Z" },
     { url = "https://files.pythonhosted.org/packages/83/e4/b903e5a5fae1e8a28cdd32a0cfbfd560b668c25b692f67768822ddc5f40f/greenlet-3.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:762612baf1161ccb8437c0161c668a688223cba28e1bf038f4eb47b13e39ccdf", size = 1618401, upload-time = "2026-04-27T12:53:31.062Z" },
     { url = "https://files.pythonhosted.org/packages/0e/e3/5ec408a329acb854fb607a122e1ee5fb3ff649f9a97952948a90803c0d8e/greenlet-3.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:57a43c6079a89713522bc4bcb9f75070ecf5d3dbad7792bfe42239362cbf2a16", size = 1682038, upload-time = "2026-04-27T12:25:31.838Z" },
     { url = "https://files.pythonhosted.org/packages/91/20/6b165108058767ee643c55c5c4904d591a830ee2b3c7dbd359828fbc829f/greenlet-3.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:3bc59be3945ae9750b9e7d45067d01ae3fe90ea5f9ade99239dabdd6e28a5033", size = 239835, upload-time = "2026-04-27T12:24:54.136Z" },
@@ -831,7 +842,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/78/a8/4522939255bb5409af4e87132f915446bf3622c2c292d14d3c38d128ae82/greenlet-3.5.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a10a732421ab4fec934783ce3e54763470d0181db6e3468f9103a275c3ed1853", size = 293614, upload-time = "2026-04-27T12:24:12.874Z" },
     { url = "https://files.pythonhosted.org/packages/15/5e/8744c52e2c027b5a8772a01561934c8835f869733e101f62075c60430340/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fc391b1566f2907d17aaebe78f8855dc45675159a775fcf9e61f8ee0078e87f", size = 650723, upload-time = "2026-04-27T12:52:45.412Z" },
     { url = "https://files.pythonhosted.org/packages/00/ef/7b4c39c03cf46ceca512c5d3f914afd85aa30b2cc9a93015b0dd73e4be6c/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:680bd0e7ad5e8daa8a4aa89f68fd6adc834b8a8036dc256533f7e08f4a4b01f7", size = 656529, upload-time = "2026-04-27T12:59:46.295Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5c/0602239503b124b70e39355cbdb39361ecfe65b87a5f2f63752c32f5286f/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1aa4ce8debcd4ea7fb2e150f3036588c41493d1d52c43538924ae1819003f4ce", size = 657015, upload-time = "2026-04-27T13:02:43.973Z" },
     { url = "https://files.pythonhosted.org/packages/0b/b5/c7768f352f5c010f92064d0063f987e7dc0cd290a6d92a34109015ce4aa1/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddb36c7d6c9c0a65f18c7258634e0c416c6ab59caac8c987b96f80c2ebda0112", size = 654364, upload-time = "2026-04-27T12:25:35.64Z" },
+    { url = "https://files.pythonhosted.org/packages/38/51/8699f865f125dc952384cb432b0f7138aa4d8f2969a7d12d0df5b94d054d/greenlet-3.5.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:728a73687e39ae9ca34e4694cbf2f049d3fbc7174639468d0f67200a97d8f9e2", size = 488275, upload-time = "2026-04-27T13:05:18.28Z" },
     { url = "https://files.pythonhosted.org/packages/ef/d0/079ebe12e4b1fc758857ce5be1a5e73f06870f2101e52611d1e71925ce54/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e5ddf316ced87539144621453c3aef229575825fe60c604e62bedc4003f372b2", size = 1614204, upload-time = "2026-04-27T12:53:32.618Z" },
     { url = "https://files.pythonhosted.org/packages/6d/89/6c2fb63df3596552d20e58fb4d96669243388cf680cff222758812c7bfaa/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4a448128607be0de65342dc9b31be7f948ef4cc0bc8832069350abefd310a8f2", size = 1675480, upload-time = "2026-04-27T12:25:34.168Z" },
     { url = "https://files.pythonhosted.org/packages/15/32/77ee8a6c1564fc345a491a4e85b3bf360e4cf26eac98c4532d2fdb96e01f/greenlet-3.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d60097128cb0a1cab9ea541186ea13cd7b847b8449a7787c2e2350da0cb82d86", size = 245324, upload-time = "2026-04-27T12:24:40.295Z" },
@@ -1215,6 +1228,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
+]
+
+[[package]]
+name = "langfuse"
+version = "4.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backoff" },
+    { name = "httpx" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/cb/a69cfdc86c3d1893dc280ef28737fb750e93804382c7d7cca96331044f41/langfuse-4.11.0.tar.gz", hash = "sha256:bfa6b05d2a68376257728db860f15736051725c56945d5099038e38731b79b61", size = 346574, upload-time = "2026-06-24T07:58:14.212Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/12/85deb81519bf6d1697875b1b68f00f7ae2e1da38baeed3b105a2ded73e8d/langfuse-4.11.0-py3-none-any.whl", hash = "sha256:aca7eab5ae94e7763b3ebe5ab0aeca677b165ea4fe9790be03513935d39196bd", size = 607683, upload-time = "2026-06-24T07:58:15.529Z" },
 ]
 
 [[package]]
@@ -1634,6 +1666,7 @@ dependencies = [
     { name = "fastapi-limiter" },
     { name = "httpx" },
     { name = "idutils" },
+    { name = "langfuse" },
     { name = "nanoid" },
     { name = "pdfplumber" },
     { name = "psycopg", extra = ["binary"] },
@@ -1666,6 +1699,7 @@ requires-dist = [
     { name = "fastapi-limiter", specifier = ">=0.2.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "idutils", specifier = ">=1.6.1" },
+    { name = "langfuse", specifier = ">=4.7.0" },
     { name = "nanoid", specifier = ">=2.0.0" },
     { name = "pdfplumber", specifier = ">=0.11.9" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.3.4" },

--- a/uv.lock
+++ b/uv.lock
@@ -1666,7 +1666,6 @@ dependencies = [
     { name = "fastapi-limiter" },
     { name = "httpx" },
     { name = "idutils" },
-    { name = "langfuse" },
     { name = "nanoid" },
     { name = "pdfplumber" },
     { name = "psycopg", extra = ["binary"] },
@@ -1680,6 +1679,11 @@ dependencies = [
     { name = "sqlmodel" },
     { name = "temporalio" },
     { name = "typer" },
+]
+
+[package.optional-dependencies]
+langfuse = [
+    { name = "langfuse" },
 ]
 
 [package.dev-dependencies]
@@ -1699,7 +1703,7 @@ requires-dist = [
     { name = "fastapi-limiter", specifier = ">=0.2.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "idutils", specifier = ">=1.6.1" },
-    { name = "langfuse", specifier = ">=4.7.0" },
+    { name = "langfuse", marker = "extra == 'langfuse'", specifier = ">=4.7.0" },
     { name = "nanoid", specifier = ">=2.0.0" },
     { name = "pdfplumber", specifier = ">=0.11.9" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.3.4" },
@@ -1714,6 +1718,7 @@ requires-dist = [
     { name = "temporalio", specifier = ">=1.27.0" },
     { name = "typer", specifier = ">=0.25.1" },
 ]
+provides-extras = ["langfuse"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Note: Right now, we are explicitly propagating workflow context. 2  important problems to be fixed:

1. The custom `propagate` context manager exists to avoid awkward inline imports in the activities. This can be used anywhere. The reason we need it is that we are passing activities around, and the way Temporal sandboxes worker code, langfuse imports don't work (Will open an issue explaining this in detail). The solution to this is to separate activity context/schemas and call them by "name", which Temporal supports.

2. Add maybe a decorator/tracing indicator on activities, so this explicit propagation isn't needed. It is not very clean with how Temporal initialises activities, but we can try. 