### PR TITLE
Make deployment worker replica number configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 ## [Unreleased]
 
+### Features
+- *(tracking)* Add created, starttime, endtime to workflows, needed for KPIs
+- Helm chart v0.2.1
+  - Add database migration job, langfuse secrets, and make the worker deployment's replicas configurable
+
+## [0.1.3] - 2026-06-29
+
+### Features
+
+- Configurable LLM settings via LLM_SETTINGS with more reliable extraction
+  - LlmSettings parses the JSON LLM_SETTINGS env var: 
+  model forwards to the chat model's request settings, output selects the structured-output strategy
+
+### Fixes
+
+- *(schema)* Keep YYYY-MM precision for publication dates
+  - The validator collapsed YYYY-MM to YYYY; keep whatever precision is given
+- *(extractor)* Stop flattening tables into full_text
+  - Tables were re-appended as pipe-joined rows that duplicated page text and added empty-cell noise,
+  bloating the prompt on dense documents. They remain in extra
+
+### Refactor
+- Add error logging for Orcha, providing more visibility on the errors in the terminal
+- *(extraction)* Flat LLM schema with configurable output mode
+
+## [0.1.2] - 2026-06-22
+
+### Fixes
+- Use valid sse framing
+
 ## [0.1.1] - 2026-06-17
 
 ### Features
@@ -14,6 +44,8 @@
 ## [0.0.1] - 2026-06-09
 _First release._
 
-[unreleased]: https://github.com/inveniosoftware/orcha/compare/v0.1.1...HEAD
-[0.1.1]: https://github.com/inveniosoftware/orcha/compare/v0.0.1...v.0.1.1
+[unreleased]: https://github.com/inveniosoftware/orcha/compare/v0.1.3...HEAD
+[0.1.3]: https://github.com/inveniosoftware/orcha/compare/v0.1.2...v0.1.3
+[0.1.2]: https://github.com/inveniosoftware/orcha/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.com/inveniosoftware/orcha/compare/v0.0.1...v0.1.1
 [0.0.1]: https://github.com/inveniosoftware/orcha/releases/tag/v0.0.1

--- a/charts/orcha/Chart.yaml
+++ b/charts/orcha/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: orcha
 description: A Helm chart for Orcha
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "0.1.3"
 
 dependencies:

--- a/charts/orcha/templates/deployment-worker.yaml
+++ b/charts/orcha/templates/deployment-worker.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "orcha.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.worker.replicaCount }}
   selector:
     matchLabels:
       {{- include "orcha.selectorLabels" . | nindent 6 }}-worker

--- a/charts/orcha/values.yaml
+++ b/charts/orcha/values.yaml
@@ -222,3 +222,6 @@ llmConfig:
   llmModel: ""  # Defaults to the app's built-in default if not set
   litellmApiBase: "<litellm-endpoint>"
   ollamaBaseUrl: "http://localhost:11434/v1"
+
+worker:
+  replicaCount: 1


### PR DESCRIPTION
refactor(helm): worker replicas as a variable
The worker deployment had hardcoded the value 1. This commit changes that by transforming the deployment replicas into a variable, which is set by default to 1 in values but can be easily overridden.

docs(changelog): releases 0.1.2 and 0.1.3
Update `CHANGELOG.md` to include unreleased, 0.1.3 and 0.1.2 changes