### PR TITLE
Helm charts cleanup

### DIFF
--- a/charts/orcha/templates/_helpers.tpl
+++ b/charts/orcha/templates/_helpers.tpl
@@ -111,6 +111,25 @@ Database Secret Name
 {{- end }}
 
 {{/*
+Database connection env vars (PG*). Include with `nindent 12` under `env:`.
+*/}}
+{{- define "orcha.databaseEnv" -}}
+- name: PGUSER
+  value: {{ include "orcha.databaseUser" . | quote }}
+- name: PGPASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "orcha.dbSecretName" . }}
+      key: password
+- name: PGHOST
+  value: {{ include "orcha.databaseHost" . | quote }}
+- name: PGPORT
+  value: {{ include "orcha.databasePort" . | quote }}
+- name: PGDATABASE
+  value: {{ include "orcha.databaseName" . | quote }}
+{{- end }}
+
+{{/*
 LLM Secret Name
 */}}
 {{- define "orcha.llmSecretName" -}}
@@ -129,6 +148,28 @@ Langfuse Secret Name
 {{- .Values.secrets.langfuse.existingSecret }}
 {{- else }}
 {{- "langfuse-secrets" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Langfuse credential env vars. Include with `nindent 12` under `env:`.
+*/}}
+{{- define "orcha.langfuseEnv" -}}
+{{- if or .Values.secrets.langfuse.publicKey .Values.secrets.langfuse.existingSecret }}
+- name: LANGFUSE_PUBLIC_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "orcha.langfuseSecretName" . }}
+      key: publicKey
+      optional: true
+{{- end }}
+{{- if or .Values.secrets.langfuse.secretKey .Values.secrets.langfuse.existingSecret }}
+- name: LANGFUSE_SECRET_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "orcha.langfuseSecretName" . }}
+      key: secretKey
+      optional: true
 {{- end }}
 {{- end }}
 

--- a/charts/orcha/templates/deployment-worker.yaml
+++ b/charts/orcha/templates/deployment-worker.yaml
@@ -36,19 +36,7 @@ spec:
             - configMapRef:
                 name: {{ include "orcha.fullname" . }}-llm-config
           env:
-            - name: PGUSER
-              value: {{ include "orcha.databaseUser" . | quote }}
-            - name: PGPASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "orcha.dbSecretName" . }}
-                  key: password
-            - name: PGHOST
-              value: {{ include "orcha.databaseHost" . | quote }}
-            - name: PGPORT
-              value: {{ include "orcha.databasePort" . | quote }}
-            - name: PGDATABASE
-              value: {{ include "orcha.databaseName" . | quote }}
+            {{- include "orcha.databaseEnv" . | nindent 12 }}
             - name: TEMPORAL_HOST
               value: {{ include "orcha.temporalHost" . | quote }}
             {{- if or .Values.secrets.llm.litellmApiKey .Values.secrets.llm.existingSecret }}
@@ -67,21 +55,8 @@ spec:
                   key: ollamaApiKey
                   optional: true
             {{- end }}
-            {{- if or .Values.secrets.langfuse.publicKey .Values.secrets.langfuse.existingSecret }}
-            - name: LANGFUSE_PUBLIC_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "orcha.langfuseSecretName" . }}
-                  key: publicKey
-                  optional: true
-            {{- end }}
-            {{- if or .Values.secrets.langfuse.secretKey .Values.secrets.langfuse.existingSecret }}
-            - name: LANGFUSE_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "orcha.langfuseSecretName" . }}
-                  key: secretKey
-                  optional: true
+            {{- with (include "orcha.langfuseEnv" .) }}
+            {{- . | trimAll "\n" | nindent 12 }}
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/orcha/templates/deployment.yaml
+++ b/charts/orcha/templates/deployment.yaml
@@ -61,19 +61,7 @@ spec:
             - configMapRef:
                 name: {{ include "orcha.fullname" . }}-llm-config
           env:
-            - name: PGUSER
-              value: {{ include "orcha.databaseUser" . | quote }}
-            - name: PGPASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "orcha.dbSecretName" . }}
-                  key: password
-            - name: PGHOST
-              value: {{ include "orcha.databaseHost" . | quote }}
-            - name: PGPORT
-              value: {{ include "orcha.databasePort" . | quote }}
-            - name: PGDATABASE
-              value: {{ include "orcha.databaseName" . | quote }}
+            {{- include "orcha.databaseEnv" . | nindent 12 }}
             - name: TEMPORAL_HOST
               value: {{ include "orcha.temporalHost" . | quote }}
             {{- if or .Values.secrets.llm.litellmApiKey .Values.secrets.llm.existingSecret }}
@@ -92,21 +80,8 @@ spec:
                   key: ollamaApiKey
                   optional: true
             {{- end }}
-            {{- if or .Values.secrets.langfuse.publicKey .Values.secrets.langfuse.existingSecret }}
-            - name: LANGFUSE_PUBLIC_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "orcha.langfuseSecretName" . }}
-                  key: publicKey
-                  optional: true
-            {{- end }}
-            {{- if or .Values.secrets.langfuse.secretKey .Values.secrets.langfuse.existingSecret }}
-            - name: LANGFUSE_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "orcha.langfuseSecretName" . }}
-                  key: secretKey
-                  optional: true
+            {{- with (include "orcha.langfuseEnv" .) }}
+            {{- . | trimAll "\n" | nindent 12 }}
             {{- end }}
           {{- if .Values.persistence.tenants.enabled }}
           volumeMounts:

--- a/charts/orcha/templates/migration-job.yaml
+++ b/charts/orcha/templates/migration-job.yaml
@@ -38,19 +38,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
-            - name: PGUSER
-              value: {{ include "orcha.databaseUser" . | quote }}
-            - name: PGPASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "orcha.dbSecretName" . }}
-                  key: password
-            - name: PGHOST
-              value: {{ include "orcha.databaseHost" . | quote }}
-            - name: PGPORT
-              value: {{ include "orcha.databasePort" . | quote }}
-            - name: PGDATABASE
-              value: {{ include "orcha.databaseName" . | quote }}
+            {{- include "orcha.databaseEnv" . | nindent 12 }}
           resources:
             {{- toYaml .Values.migrations.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/orcha/templates/migration-job.yaml
+++ b/charts/orcha/templates/migration-job.yaml
@@ -11,9 +11,6 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   backoffLimit: {{ .Values.migrations.backoffLimit }}
-  {{- with .Values.migrations.ttlSecondsAfterFinished }}
-  ttlSecondsAfterFinished: {{ . }}
-  {{- end }}
   template:
     metadata:
       labels:

--- a/charts/orcha/templates/migration-job.yaml
+++ b/charts/orcha/templates/migration-job.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: migrations
   annotations:
     "helm.sh/hook": post-install,pre-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   backoffLimit: {{ .Values.migrations.backoffLimit }}
   template:

--- a/charts/orcha/values.yaml
+++ b/charts/orcha/values.yaml
@@ -10,7 +10,6 @@ image:
 migrations:
   enabled: true
   backoffLimit: 3
-  ttlSecondsAfterFinished: 300
   resources: {}
 
 serviceAccount:


### PR DESCRIPTION
- **refactor(helm): extract shared db and langfuse env helpers**
  

- **fix(helm): run migrations on pre-install**
  Migrations now finish before the app and worker pods start serving. A fresh install therefore needs a pre-existing DB secret (secrets.db.existingSecret), since the chart-managed db-secrets does not exist yet during the pre-install hook.
  

- **fix(helm): keep failed migration job logs by dropping the TTL**
  ttlSecondsAfterFinished let the TTL controller reap failed Jobs and their logs. Cleanup is left to the hook-delete-policy, which retains a failed Job until the next install or upgrade.
  