### PR TITLE
Fix creators parsing

### DIFF
--- a/app/extractors/pdfplumber.py
+++ b/app/extractors/pdfplumber.py
@@ -7,6 +7,9 @@ import re
 from io import BytesIO
 from typing import Any, Dict, List, Optional
 
+from idutils.normalizers import normalize_orcid
+from idutils.validators import is_orcid
+
 from .base import BaseExtractor
 from .utils import resolve_pages
 
@@ -134,6 +137,5 @@ class PdfplumberExtractor(BaseExtractor):
         return "".join(parts)
 
     def _extract_orcid_id(self, url: str) -> str | None:
-        """Extract ORCID ID from an orcid.org URL."""
-        match = re.search(r"orcid\.org/(\d{4}-\d{4}-\d{4}-\d{3}[\dX])", url)
-        return match.group(1) if match else None
+        """Return the bare ORCID from an orcid.org URL, or None."""
+        return normalize_orcid(url) if is_orcid(url) else None

--- a/app/extractors/pdfplumber.py
+++ b/app/extractors/pdfplumber.py
@@ -10,6 +10,12 @@ from typing import Any, Dict, List, Optional
 from .base import BaseExtractor
 from .utils import resolve_pages
 
+# Tolerances in PDF points for tying an ORCID icon to its author's name: the
+# icon sits on the name's text line, just past its right edge. Empirical, tuned
+# on the sample papers.
+_SAME_LINE_PT = 6  # max vertical gap counting word and icon as one line
+_ICON_GAP_PT = 2  # max horizontal gap from the word's right edge to the icon
+
 
 class PdfplumberExtractor(BaseExtractor):
     """Extract content using pdfplumber."""
@@ -101,7 +107,8 @@ class PdfplumberExtractor(BaseExtractor):
             on_line = [
                 i
                 for i, w in enumerate(words)
-                if abs(w["top"] - annot["top"]) < 6 and w["x1"] <= annot["x0"] + 2
+                if abs(w["top"] - annot["top"]) < _SAME_LINE_PT
+                and w["x1"] <= annot["x0"] + _ICON_GAP_PT
             ]
             if not on_line:
                 continue

--- a/app/extractors/pdfplumber.py
+++ b/app/extractors/pdfplumber.py
@@ -3,6 +3,7 @@
 
 """PDFPlumber-based PDF extractor."""
 
+import re
 from io import BytesIO
 from typing import Any, Dict, List, Optional
 
@@ -26,18 +27,20 @@ class PdfplumberExtractor(BaseExtractor):
         with pdfplumber.open(BytesIO(pdf_bytes)) as pdf:
             page_count = len(pdf.pages)
 
-            # Resolve page selection
             resolved_pages = resolve_pages(pages, page_count)
             page_indices = resolved_pages if resolved_pages else range(page_count)
 
             for page_num in page_indices:
                 page = pdf.pages[page_num]
-                # Extract text with x_tolerance=2 to better detect word boundaries
-                # Default x_tolerance=3 merges words like "PhilipBull" that have gaps
+                page_annots = page.annots or []
+                # x_tolerance=2: the default (3) merges spaced words like "PhilipBull"
                 text = page.extract_text(x_tolerance=2) or ""
+                # ORCIDs live only in link annotations. Splice each one next to its
+                # author so the pairing survives; a bare list misaligns when some
+                # authors have no ORCID.
+                text = self._inline_orcids(page, text, page_annots)
                 full_text_parts.append(text)
 
-                # Extract tables
                 page_tables = page.extract_tables()
                 for table in page_tables:
                     if table:
@@ -49,34 +52,21 @@ class PdfplumberExtractor(BaseExtractor):
                             }
                         )
 
-                # Extract hyperlinks (annotations with URI)
-                if page.annots:
-                    for annot in page.annots:
-                        uri = annot.get("uri")
-                        if uri:
-                            link_type = self._classify_link(uri)
-                            hyperlinks.append(
-                                {
-                                    "url": uri,
-                                    "page": page_num + 1,
-                                    "type": link_type,
-                                }
-                            )
+                for annot in page_annots:
+                    uri = annot.get("uri")
+                    if uri:
+                        link_type = self._classify_link(uri)
+                        hyperlinks.append(
+                            {
+                                "url": uri,
+                                "page": page_num + 1,
+                                "type": link_type,
+                            }
+                        )
 
-        # Page text already contains table cell text in reading order; the
-        # structured `tables` are returned in `extra` rather than flattened into
-        # `full_text`, which only duplicated content and added empty-cell noise.
+        # Tables go in `extra`, not `full_text`; the page text already holds each
+        # cell in reading order.
         full_text = "\n\n".join(full_text_parts)
-
-        # Extract ORCID IDs from hyperlinks and add to full_text
-        # This makes ORCIDs discoverable even when they're only in link URLs
-        # (not visible text)
-        orcid_ids = [
-            self._extract_orcid_id(h["url"]) for h in hyperlinks if h["type"] == "orcid"
-        ]
-        orcid_ids = [oid for oid in orcid_ids if oid]  # filter None
-        if orcid_ids:
-            full_text += "\n\nORCID IDs from hyperlinks: " + " ".join(orcid_ids)
 
         return {
             "full_text": full_text,
@@ -92,9 +82,34 @@ class PdfplumberExtractor(BaseExtractor):
             },
         }
 
+    def _inline_orcids(self, page, text: str, annots: list) -> str:
+        """Splice each ORCID inline after the author its icon is anchored to.
+
+        The icon sits just right of the author on the same line, so the word
+        ending nearest left of it is that author's token (name plus any
+        affiliation marker, e.g. "Bull1,2"). The first text match is the author
+        block near the top of the page.
+        """
+        words = None
+        for annot in annots:
+            orcid = self._extract_orcid_id(annot.get("uri") or "")
+            if not orcid:
+                continue
+            if words is None:
+                words = page.extract_words(x_tolerance=2)
+            on_line = [
+                w
+                for w in words
+                if abs(w["top"] - annot["top"]) < 6 and w["x1"] <= annot["x0"] + 2
+            ]
+            if not on_line:
+                continue
+            anchor = max(on_line, key=lambda w: w["x1"])["text"].strip(" ,;")
+            if anchor and anchor in text:
+                text = text.replace(anchor, f"{anchor} (ORCID: {orcid})", 1)
+        return text
+
     def _extract_orcid_id(self, url: str) -> str | None:
         """Extract ORCID ID from an orcid.org URL."""
-        import re
-
         match = re.search(r"orcid\.org/(\d{4}-\d{4}-\d{4}-\d{3}[\dX])", url)
         return match.group(1) if match else None

--- a/app/extractors/pdfplumber.py
+++ b/app/extractors/pdfplumber.py
@@ -87,10 +87,11 @@ class PdfplumberExtractor(BaseExtractor):
 
         The icon sits just right of the author on the same line, so the word
         ending nearest left of it is that author's token (name plus any
-        affiliation marker, e.g. "Bull1,2"). The first text match is the author
-        block near the top of the page.
+        affiliation marker, e.g. "Smith1,2"). Edits are collected and applied in
+        a single pass.
         """
         words = None
+        edits: list[tuple[int, str]] = []
         for annot in annots:
             orcid = self._extract_orcid_id(annot.get("uri") or "")
             if not orcid:
@@ -98,16 +99,32 @@ class PdfplumberExtractor(BaseExtractor):
             if words is None:
                 words = page.extract_words(x_tolerance=2)
             on_line = [
-                w
-                for w in words
+                i
+                for i, w in enumerate(words)
                 if abs(w["top"] - annot["top"]) < 6 and w["x1"] <= annot["x0"] + 2
             ]
             if not on_line:
                 continue
-            anchor = max(on_line, key=lambda w: w["x1"])["text"].strip(" ,;")
-            if anchor and anchor in text:
-                text = text.replace(anchor, f"{anchor} (ORCID: {orcid})", 1)
-        return text
+            idx = max(on_line, key=lambda i: words[i]["x1"])
+            anchor = words[idx]["text"]
+            # Match the anchor as a whole whitespace-bounded token at its own
+            # occurrence, so a prefix like "Alex" can't land inside "Alexandra"
+            # and marker-suffixed tokens (e.g. "Smith1,2") still match.
+            ordinal = sum(1 for w in words[:idx] if w["text"] == anchor)
+            occ = list(re.finditer(rf"(?<!\S){re.escape(anchor)}(?!\S)", text))
+            if ordinal < len(occ):
+                edits.append((occ[ordinal].end(), orcid))
+
+        if not edits:
+            return text
+        edits.sort()
+        parts, prev = [], 0
+        for offset, orcid in edits:
+            parts.append(text[prev:offset])
+            parts.append(f" (ORCID: {orcid})")
+            prev = offset
+        parts.append(text[prev:])
+        return "".join(parts)
 
     def _extract_orcid_id(self, url: str) -> str | None:
         """Extract ORCID ID from an orcid.org URL."""

--- a/app/schemas/metadata_suggestions.py
+++ b/app/schemas/metadata_suggestions.py
@@ -5,29 +5,11 @@
 
 # from __future__ import annotations
 
-import re
 from typing import Annotated, Literal
 
+from idutils.normalizers import normalize_orcid
+from idutils.validators import is_orcid
 from pydantic import BaseModel, Field, field_validator
-
-_ORCID_RE = re.compile(r"\d{4}-\d{4}-\d{4}-\d{3}[\dX]")
-
-
-def valid_orcid(value: str) -> bool:
-    """Check ORCID shape and ISO 7064 MOD 11-2 check digit.
-
-    Rejects fabrications like ``0000-0000-0000-0000`` (wrong check digit) that
-    the LLM emits for authors with no ORCID, as well as digit-garbled IDs.
-    """
-    value = value.strip()
-    if not _ORCID_RE.fullmatch(value):
-        return False
-    digits = value.replace("-", "")
-    total = 0
-    for ch in digits[:15]:
-        total = (total + int(ch)) * 2
-    check = (12 - total % 11) % 11
-    return ("X" if check == 10 else str(check)) == digits[15]
 
 
 class Creator(BaseModel):
@@ -48,7 +30,7 @@ class Creator(BaseModel):
             "ORCID identifier as the bare 16-digit ID (four groups of four, "
             "final character may be 'X'), without the orcid.org URL prefix"
         ),
-        examples=["0000-0001-2345-6789", "0000-0001-0002-000X"],
+        examples=["0000-0002-1111-1115", "0000-0002-6789-012X"],
     )
 
     @field_validator("name")
@@ -162,7 +144,7 @@ class ExtractedMetadata(BaseModel):
             "is the ORCID of creators[i]; empty string when an author has none. "
             "Bare 16-digit form (four groups of four, last may be 'X'), no URL."
         ),
-        examples=[["0000-0001-2345-6789", ""]],
+        examples=[["0000-0002-1111-1115", ""]],
     )
     creator_affiliations: list[str] = Field(
         default_factory=list,
@@ -201,14 +183,14 @@ class ExtractedMetadata(BaseModel):
         if self.creators:
             value = []
             for i, name in enumerate(self.creators):
-                # Drop ORCIDs that fail the check digit here, in post-processing,
-                # not on the LLM output schema: a schema error would be fed back
-                # and the model would invent a checksum-valid fake to satisfy it.
+                # Validate/normalize here, not on the LLM output schema, where a
+                # fed-back error would make the model invent a valid-looking fake.
                 orcid = self._at(self.creator_orcids, i)
+                orcid = normalize_orcid(orcid).upper() if is_orcid(orcid) else None
                 value.append(
                     Creator(
                         name=name,
-                        orcid=orcid if valid_orcid(orcid) else None,
+                        orcid=orcid,
                         affiliation=self._at(self.creator_affiliations, i) or None,
                     )
                 )

--- a/app/schemas/metadata_suggestions.py
+++ b/app/schemas/metadata_suggestions.py
@@ -5,9 +5,29 @@
 
 # from __future__ import annotations
 
+import re
 from typing import Annotated, Literal
 
 from pydantic import BaseModel, Field, field_validator
+
+_ORCID_RE = re.compile(r"\d{4}-\d{4}-\d{4}-\d{3}[\dX]")
+
+
+def valid_orcid(value: str) -> bool:
+    """Check ORCID shape and ISO 7064 MOD 11-2 check digit.
+
+    Rejects fabrications like ``0000-0000-0000-0000`` (wrong check digit) that
+    the LLM emits for authors with no ORCID, as well as digit-garbled IDs.
+    """
+    value = value.strip()
+    if not _ORCID_RE.fullmatch(value):
+        return False
+    digits = value.replace("-", "")
+    total = 0
+    for ch in digits[:15]:
+        total = (total + int(ch)) * 2
+    check = (12 - total % 11) % 11
+    return ("X" if check == 10 else str(check)) == digits[15]
 
 
 class Creator(BaseModel):
@@ -28,7 +48,7 @@ class Creator(BaseModel):
             "ORCID identifier as the bare 16-digit ID (four groups of four, "
             "final character may be 'X'), without the orcid.org URL prefix"
         ),
-        examples=["0000-0001-2345-6789", "0000-0002-1234-567X"],
+        examples=["0000-0001-2345-6789", "0000-0001-0002-000X"],
     )
 
     @field_validator("name")
@@ -179,14 +199,19 @@ class ExtractedMetadata(BaseModel):
         if self.description:
             suggestions.append(DescriptionSuggestion(value=self.description))
         if self.creators:
-            value = [
-                Creator(
-                    name=name,
-                    orcid=self._at(self.creator_orcids, i) or None,
-                    affiliation=self._at(self.creator_affiliations, i) or None,
+            value = []
+            for i, name in enumerate(self.creators):
+                # Drop ORCIDs that fail the check digit here, in post-processing,
+                # not on the LLM output schema: a schema error would be fed back
+                # and the model would invent a checksum-valid fake to satisfy it.
+                orcid = self._at(self.creator_orcids, i)
+                value.append(
+                    Creator(
+                        name=name,
+                        orcid=orcid if valid_orcid(orcid) else None,
+                        affiliation=self._at(self.creator_affiliations, i) or None,
+                    )
                 )
-                for i, name in enumerate(self.creators)
-            ]
             creators = CreatorsSuggestion(value=value)
             if creators.value:
                 suggestions.append(creators)

--- a/app/schemas/metadata_suggestions.py
+++ b/app/schemas/metadata_suggestions.py
@@ -15,10 +15,21 @@ class Creator(BaseModel):
 
     name: str = Field(
         description="Full name in '<family>, <given>' format",
-        examples=["Smith, John"],
+        examples=["Doe, Jane", "van der Berg, A."],
     )
-    affiliation: str | None = None
-    orcid: str | None = None
+    affiliation: str | None = Field(
+        default=None,
+        description="Institution or organization the creator is affiliated with",
+        examples=["CERN", "University of Cambridge"],
+    )
+    orcid: str | None = Field(
+        default=None,
+        description=(
+            "ORCID identifier as the bare 16-digit ID (four groups of four, "
+            "final character may be 'X'), without the orcid.org URL prefix"
+        ),
+        examples=["0000-0001-2345-6789", "0000-0002-1234-567X"],
+    )
 
     @field_validator("name")
     @classmethod
@@ -101,17 +112,50 @@ class MetadataSuggestions(BaseModel):
 
 
 class ExtractedMetadata(BaseModel):
-    """Flat schema the LLM fills; converted to ``MetadataSuggestions``.
+    """Flat schema the LLM fills, converted to ``MetadataSuggestions``.
 
-    Smaller models handle a flat object far better than the discriminated union.
+    Creators are parallel lists, not nested objects. gpt-oss-20b fills flat
+    top-level lists in a tool call but drops a field nested under each creator,
+    so a per-creator ``orcid`` gets lost. ``creator_orcids[i]`` and
+    ``creator_affiliations[i]`` belong to ``creators[i]``.
     """
 
-    title: str | None = Field(default=None, description="Document title")
-    description: str | None = Field(default=None, description="Abstract or summary")
-    creators: list[Creator] = Field(
-        default_factory=list, description="Authors or creators"
+    title: str | None = Field(
+        default=None,
+        description="Document title",
+        examples=["A Concise Title Describing the Work"],
     )
-    doi: str | None = Field(default=None, description="The Digital Object Identifier")
+    description: str | None = Field(
+        default=None,
+        description="Abstract or summary",
+        examples=["A short summary of the document's purpose, methods, and findings."],
+    )
+    creators: list[str] = Field(
+        default_factory=list,
+        description="Creator full names in '<family>, <given>' format, in order",
+        examples=[["Doe, Jane", "van der Berg, A."]],
+    )
+    creator_orcids: list[str] = Field(
+        default_factory=list,
+        description=(
+            "ORCID iD per creator, parallel to `creators` so creator_orcids[i] "
+            "is the ORCID of creators[i]; empty string when an author has none. "
+            "Bare 16-digit form (four groups of four, last may be 'X'), no URL."
+        ),
+        examples=[["0000-0001-2345-6789", ""]],
+    )
+    creator_affiliations: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Affiliation per creator, parallel to `creators`; empty string when unknown"
+        ),
+        examples=[["CERN", "University of Cambridge"]],
+    )
+    doi: str | None = Field(
+        default=None,
+        description="The Digital Object Identifier, as a bare DOI without a URL prefix",
+        examples=["10.1234/example.5678"],
+    )
     publication_date: str | None = Field(
         default=None,
         description=(
@@ -122,6 +166,11 @@ class ExtractedMetadata(BaseModel):
         examples=["2014-07-17", "2014-07", "2014"],
     )
 
+    @staticmethod
+    def _at(values: list[str], i: int) -> str:
+        """Return the i-th parallel value, or '' when the list is shorter."""
+        return values[i] if i < len(values) else ""
+
     def to_suggestions(self) -> MetadataSuggestions:
         """Build the typed suggestions, dropping null/empty fields."""
         suggestions: list[MetadataSuggestion] = []
@@ -130,7 +179,15 @@ class ExtractedMetadata(BaseModel):
         if self.description:
             suggestions.append(DescriptionSuggestion(value=self.description))
         if self.creators:
-            creators = CreatorsSuggestion(value=self.creators)
+            value = [
+                Creator(
+                    name=name,
+                    orcid=self._at(self.creator_orcids, i) or None,
+                    affiliation=self._at(self.creator_affiliations, i) or None,
+                )
+                for i, name in enumerate(self.creators)
+            ]
+            creators = CreatorsSuggestion(value=value)
             if creators.value:
                 suggestions.append(creators)
         if self.doi:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "PyJWT>=2.12.1",
     "cryptography>=48.0.0",
     "alembic>=1.18.4",
+    "idutils>=1.6.1",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -999,6 +999,18 @@ wheels = [
 ]
 
 [[package]]
+name = "idutils"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "isbnlib2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/1b/8d35c02739e1bcf53c23107324f56565e42ab87e53d3cb82322368a024ec/idutils-1.6.1.tar.gz", hash = "sha256:4604827ed52aa272843f1c53b25ed3be864868a9abcdf0ee7932df56f94458b8", size = 35853, upload-time = "2026-05-28T08:54:17.464Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/9c/aa092c1daaac95ba6b19d9d2f0542a27692c11ec4e3175f6f98e08d49681/idutils-1.6.1-py2.py3-none-any.whl", hash = "sha256:de24b0f5d9317052223819a99893f913d752820c3d7046d3a4e970b1221e0723", size = 23814, upload-time = "2026-05-28T08:54:16.43Z" },
+]
+
+[[package]]
 name = "importlib-metadata"
 version = "8.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1017,6 +1029,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "isbnlib2"
+version = "3.11.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/9d/18f104b965db7ee0ac5543d2c6c39cd44b6f4f016484cd57a0b56c1f15c5/isbnlib2-3.11.19.tar.gz", hash = "sha256:37c2833b6feb6b05abfc028134149dffc813def244cd1bdc251ab3a3fabe08dd", size = 56888, upload-time = "2026-06-14T11:13:59.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/af/bce0a35779136f2301e8442e62094890da8d36504d0ab71b370bfc3631ac/isbnlib2-3.11.19-py3-none-any.whl", hash = "sha256:fec59123b56c4b71ff70ccdfa898a3df2c38618642b2d73650318a7a0b565ec1", size = 67860, upload-time = "2026-06-14T11:13:58.185Z" },
 ]
 
 [[package]]
@@ -1612,6 +1633,7 @@ dependencies = [
     { name = "fastapi", extra = ["standard"] },
     { name = "fastapi-limiter" },
     { name = "httpx" },
+    { name = "idutils" },
     { name = "nanoid" },
     { name = "pdfplumber" },
     { name = "psycopg", extra = ["binary"] },
@@ -1643,6 +1665,7 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.136.1" },
     { name = "fastapi-limiter", specifier = ">=0.2.0" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "idutils", specifier = ">=1.6.1" },
     { name = "nanoid", specifier = ">=2.0.0" },
     { name = "pdfplumber", specifier = ">=0.11.9" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.3.4" },


### PR DESCRIPTION
- **fix(schema): flatten creators into parallel lists**
  gpt-oss-20b drops an ORCID nested under each creator in tool calls; parallel name/orcid/affiliation lists survive. Adds synthetic field examples.
  

- **fix(extractor): inline ORCIDs next to their author**
  A bare appended list misaligned when some authors had no ORCID; inline placement keeps each ID tied to its author.
  

- **fix(schema): drop ORCIDs that fail the check digit**
  gpt-oss fabricates 0000-0000-0000-0000 for authors with no ORCID. Filter by the ISO 7064 check digit in to_suggestions, not on the LLM output schema, since a schema error feeds back and the model invents a checksum-valid fake instead of leaving it null.
  