### PR TITLE
feat(extract): reduce fabricated metadata suggestions

### DIFF
--- a/app/activities/extract_metadata.py
+++ b/app/activities/extract_metadata.py
@@ -3,8 +3,12 @@
 
 """LLM-based metadata suggestions activity."""
 
+import re
 from datetime import timedelta
+from difflib import SequenceMatcher
 
+from idutils.normalizers import normalize_doi
+from idutils.validators import is_doi
 from pydantic import BaseModel, Field
 from pydantic_ai import Agent, PromptedOutput
 from pydantic_ai.models.openai import OpenAIChatModel, OpenAIChatModelSettings
@@ -48,8 +52,61 @@ class ExtractMetadataRequest(BaseModel):
 INSTRUCTIONS = (
     "You extract bibliographic metadata from the document text. "
     "Only include information clearly stated in the text; "
-    "leave anything you cannot determine empty."
+    "leave anything you cannot determine empty. "
+    "If a piece of information is not present in the document text, leave that "
+    "field null or empty. Never guess, invent, or use placeholder values."
 )
+
+# Below this many non-whitespace-stripped chars the extraction is effectively empty
+# (broken/image-only PDFs). Models fabricate whole records, output schema
+# placeholders/examples, loop in reasoning, or crash tool-call parsers on empty input.
+MIN_TEXT_CHARS = 50
+
+# Values the model returns for these fields must (fuzzily) be present in the source
+# text, else they're skipped.
+_PRESENCE_THRESHOLDS = {
+    "title": 0.85,
+    "description": 0.80,
+}
+
+
+def _coverage(value: str, text: str) -> float:
+    """Fraction of `value` found in `text` (ordered matching blocks)."""
+    sm = SequenceMatcher(None, value, text, autojunk=False)
+    matched = sum(b.size for b in sm.get_matching_blocks())
+    return matched / len(value) if value else 1.0
+
+
+def _normalize_text(s: str) -> str:
+    return re.sub(r"\s+", " ", str(s or "").casefold()).strip()
+
+
+def _clear_absent_fields(output: ExtractedMetadata, text: str) -> None:
+    """Null title/description/doi whose values aren't present in the source text."""
+    normalized_text = _normalize_text(text)
+    for field, threshold in _PRESENCE_THRESHOLDS.items():
+        value = getattr(output, field)
+        if not value:
+            continue
+
+        normalized_value = _normalize_text(value)
+        if (
+            normalized_value in normalized_text
+            or _coverage(normalized_value, normalized_text) >= threshold
+        ):
+            continue
+        setattr(output, field, None)
+
+    # DOIs wrap across lines and may carry a URL or 'doi:' prefix: normalize to
+    # the bare identifier and match it whitespace-insensitively in the source.
+    # A non-DOI is fabricated by construction (and would crash normalize_doi).
+    if output.doi:
+        if not is_doi(output.doi):
+            output.doi = None
+        else:
+            squashed = re.sub(r"\s+", "", text).casefold()
+            if normalize_doi(output.doi).casefold() not in squashed:
+                output.doi = None
 
 
 # Extra instruction pieces for prompted output (no native tool calls): cap
@@ -98,8 +155,13 @@ async def extract_metadata_with_llm(
     context: WorkflowContext,
 ) -> MetadataSuggestions:
     """Generate typed metadata suggestions using an LLM."""
+    if len(request.text.strip()) < MIN_TEXT_CHARS:
+        # No usable text: skip the LLM entirely rather than let it fabricate.
+        return MetadataSuggestions(suggestions=[])
+
     agent = _build_agent(get_settings().llm)
     with propagate_langfuse_context(context, trace_name="extract_metadata"):
         result = await agent.run(request.text)
 
+    _clear_absent_fields(result.output, request.text)
     return result.output.to_suggestions()

--- a/tests/test_extract_metadata.py
+++ b/tests/test_extract_metadata.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the extract_metadata activity's non-LLM guards.
+
+Covers the two deterministic layers around the LLM call: the empty-text gate
+(no LLM on image-only PDFs) and the post-hoc presence check (null values not
+present in the source text). The LLM call itself is not exercised here.
+"""
+
+import asyncio
+
+import pytest
+
+from app.activities.extract_metadata import (
+    MIN_TEXT_CHARS,
+    ExtractMetadataRequest,
+    _clear_absent_fields,
+    extract_metadata_with_llm,
+)
+from app.schemas.metadata_suggestions import ExtractedMetadata
+from app.workflows.specs import WorkflowContext
+
+SOURCE = (
+    "Deep Learning for Metadata Extraction\n\n"
+    "Jane Doe, A. van der Berg\n\n"
+    "Abstract: We present a method for extracting bibliographic metadata "
+    "from scholarly PDFs using large language models.\n\n"
+    "https://doi.org/10.1234/example.5678"
+)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "kept"),
+    [
+        # title: verbatim substring is kept; a fabricated title is nulled
+        ("title", "Deep Learning for Metadata Extraction", True),
+        ("title", "A Concise Title Describing the Work", False),
+        # description: near-verbatim (above 0.80 coverage) kept; invented nulled
+        (
+            "description",
+            "We present a method for extracting bibliographic metadata "
+            "from scholarly PDFs using large language models.",
+            True,
+        ),
+        (
+            "description",
+            "A short summary of the document's purpose and findings.",
+            False,
+        ),
+    ],
+)
+def test_null_absent_text_fields(field, value, kept):
+    """Title/description present in the source survive; fabricated ones are nulled."""
+    output = ExtractedMetadata(**{field: value})
+    _clear_absent_fields(output, SOURCE)
+    assert getattr(output, field) == (value if kept else None)
+
+
+@pytest.mark.parametrize(
+    ("doi", "kept"),
+    [
+        ("10.1234/example.5678", True),  # bare form present in the URL in text
+        ("https://doi.org/10.1234/example.5678", True),  # normalized before match
+        (
+            "doi:10.1234/EXAMPLE.5678",
+            True,
+        ),  # prefix stripped, matched case-insensitively
+        ("10.9999/not.in.text", False),  # fabricated DOI nulled
+        ("not-a-doi", False),  # non-DOI cleared (would crash normalize_doi unguarded)
+    ],
+)
+def test_null_absent_doi(doi, kept):
+    """DOIs present in the text (bare or via URL) are kept; absent ones nulled."""
+    output = ExtractedMetadata(doi=doi)
+    _clear_absent_fields(output, SOURCE)
+    assert (output.doi == doi) if kept else (output.doi is None)
+
+
+def test_null_absent_wrapped_doi_matches_across_linebreak():
+    """A DOI wrapped across a line break still matches (whitespace-insensitive)."""
+    output = ExtractedMetadata(doi="10.1234/example.5678")
+    _clear_absent_fields(output, "identifier 10.1234/\nexample.5678 end")
+    assert output.doi == "10.1234/example.5678"
+
+
+def test_null_absent_leaves_empty_fields_untouched():
+    """The presence check never invents values for fields the model left empty."""
+    output = ExtractedMetadata()
+    _clear_absent_fields(output, SOURCE)
+    assert output.title is None
+    assert output.description is None
+    assert output.doi is None
+
+
+@pytest.mark.parametrize("text", ["", "   \n\t ", "x" * (MIN_TEXT_CHARS - 1)])
+def test_skip_empty_returns_no_suggestions(text):
+    """Below the char threshold the activity returns empty metadata, no LLM call."""
+    # No settings/agent are required on this path; a real LLM would fabricate here.
+    request = ExtractMetadataRequest(text=text)
+    context = WorkflowContext(workflow_id="wf-1", tenant_id="t-1")
+    result = asyncio.run(extract_metadata_with_llm(request, context))
+    assert result.suggestions == []


### PR DESCRIPTION
- Prompt hardening: tell the model to leave absent fields empty and never
  use placeholder values.
- Skip the LLM on near-empty text (<50 chars). Image-only PDFs otherwise
  push models to fabricate whole records or crash tool-call parsers; a
  length check removes that failure class for every model.
- Post-hoc, clear title/description/doi whose values aren't present in the
  source text (fuzzy match for text, idutils-normalized whitespace-insensitive
  match for DOI). Run after the LLM, not fed back as a retry: retrying
  corrects little and turns recoverable items into hard errors.
