### PR TITLE
Fix creators and description schema prompts

### DIFF
--- a/app/schemas/metadata_suggestions.py
+++ b/app/schemas/metadata_suggestions.py
@@ -129,12 +129,20 @@ class ExtractedMetadata(BaseModel):
     )
     description: str | None = Field(
         default=None,
-        description="Abstract or summary",
-        examples=["A short summary of the document's purpose, methods, and findings."],
+        description=(
+            "Abstract or executive summary of the document, copied word-for-word, "
+            "complete and unchanged; never paraphrase, shorten, or write a new "
+            "summary. Null if the document has no abstract or summary."
+        ),
+        examples=["The abstract of the document, word for word."],
     )
     creators: list[str] = Field(
         default_factory=list,
-        description="Creator full names in '<family>, <given>' format, in order",
+        description=(
+            "Creator full names in '<family>, <given>' format, in order. Include "
+            "every author named in the document; never truncate the list or use "
+            "et al."
+        ),
         examples=[["Doe, Jane", "van der Berg, A."]],
     )
     creator_orcids: list[str] = Field(

--- a/app/schemas/metadata_suggestions.py
+++ b/app/schemas/metadata_suggestions.py
@@ -149,9 +149,15 @@ class ExtractedMetadata(BaseModel):
     creator_affiliations: list[str] = Field(
         default_factory=list,
         description=(
-            "Affiliation per creator, parallel to `creators`; empty string when unknown"
+            "Affiliation per creator, parallel to `creators`; empty string when "
+            "unknown. Affiliations are often marked with numbers or symbols after "
+            "author names; resolve each author's marker to its affiliation. Copy "
+            "the affiliation as written, including any department or institute, "
+            "but leave out the marker and any street address, city, postal code, "
+            "or country: 'CERN, Geneva, Switzerland' -> 'CERN'. If an author has "
+            "several affiliations, give the first."
         ),
-        examples=[["CERN", "University of Cambridge"]],
+        examples=[["CERN", "Department of Physics, University of Oxford"]],
     )
     doi: str | None = Field(
         default=None,


### PR DESCRIPTION
I tested multiple variants for each field (but not all their combinations), arriving at these best-performing phrasings. Most importantly, these also dropped hallucinations significantly.

- **fix(schema): tighten `creator_affiliations` extraction guidance**
  Models kept returning affiliations with footnote markers and trailing postal addresses, so the description now tells it to resolve each author's marker and drop the marker and address.
  

- **fix(schema): improve description and author names prompt**
  The model was paraphrasing abstracts and cutting author lists short, so the
  description and creators descriptions now say to copy the summary word-for-word
  and include every author instead of using et al. Both are A/B-tested, so leave
  them as is.
  