### PR TITLE
fix(workflow): handle 1-page files

### DIFF
--- a/app/extractors/utils.py
+++ b/app/extractors/utils.py
@@ -10,11 +10,11 @@ from .errors import InvalidPageSelectionError
 
 def resolve_pages(pages: Optional[List[int]], total_pages: int) -> Optional[List[int]]:
     """Resolve page list with negative indices to 0-based page numbers."""
-    if pages is None:
-        return None
-
     if total_pages < 1:
         raise InvalidPageSelectionError("Cannot select pages from a PDF with no pages")
+
+    if pages is None:
+        pages = [1, 2] if total_pages >= 2 else [1]
 
     resolved = set()
     for p in pages:

--- a/app/workflows/extract_metadata_workflow.py
+++ b/app/workflows/extract_metadata_workflow.py
@@ -3,7 +3,7 @@
 
 from datetime import timedelta
 
-from pydantic import Field, HttpUrl
+from pydantic import HttpUrl
 from pydantic_ai.durable_exec.temporal import (
     PydanticAIWorkflow,
 )
@@ -37,7 +37,7 @@ class ExtractMetadataParams(WorkflowParams):
 
     url: HttpUrl
     extractor: str = "pdfplumber"
-    pages: list[int] | None = Field(default_factory=lambda: [1, 2])
+    pages: list[int] | None = None
 
 
 @workflow.defn

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -471,7 +471,7 @@ def test_create_workflow_stamps_tenant_id(client, db_session, mocker):
     assert wf.params == {
         "url": "https://example.com/doc.pdf",
         "extractor": "pdfplumber",
-        "pages": [1, 2],
+        "pages": None,
     }
     assert wf.public_id == created_id
     assert response.json()["user_id"] == "user-123"

--- a/tests/test_resolve_pages.py
+++ b/tests/test_resolve_pages.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+"""Tests for resolve_pages page-selection utility."""
+
+import pytest
+
+from app.extractors.errors import InvalidPageSelectionError
+from app.extractors.utils import resolve_pages
+
+
+@pytest.mark.parametrize(
+    ("total_pages", "expected"),
+    [
+        (1, [0]),
+        (2, [0, 1]),
+        (5, [0, 1]),
+    ],
+)
+def test_pages_none(total_pages, expected):
+    """pages=None resolves to [1,2] for multi-page files and [1] for single-page."""
+    assert resolve_pages(None, total_pages) == expected
+
+
+@pytest.mark.parametrize(
+    ("pages", "total_pages", "expected"),
+    [
+        ([1], 1, [0]),
+        ([1, 2], 2, [0, 1]),
+        ([1, 2], 5, [0, 1]),
+        ([-1], 3, [2]),  # last page
+        ([-2, -1], 3, [1, 2]),  # last two pages
+    ],
+)
+def test_explicit_pages(pages, total_pages, expected):
+    """Explicit pages passed should resolve correctly considering 1-based indexing."""
+    assert resolve_pages(pages, total_pages) == expected
+
+
+def test_explicit_out_of_range():
+    """Explicit [1, 2] on a single-page file must raise."""
+    with pytest.raises(InvalidPageSelectionError, match="out of range"):
+        resolve_pages([1, 2], 1)
+
+
+def test_zero_page():
+    """Passing 0 in pages must raise, as 0 is not allowed."""
+    with pytest.raises(InvalidPageSelectionError, match="1-based"):
+        resolve_pages([0, 1], 3)
+
+
+def test_empty_pdf():
+    """Empty files raise an error."""
+    with pytest.raises(InvalidPageSelectionError, match="no pages"):
+        resolve_pages(None, 0)


### PR DESCRIPTION
The default pages value hardcoded that pages [1, 2] would be extracted if no other value is passed. We change the default to None, and the util `resolve_pages` handle these cases, setting the pages to extract to [1, 2] if the file has 2 pages or more, or only 1 if the document has 1 page.

