### PR TITLE
Add evals pipeline to orcha

### DIFF
--- a/evals/dataset.py
+++ b/evals/dataset.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+"""Langfuse dataset management."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _expected_output_from_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
+    """Map dataset metadata to the expected output schema."""
+    title = metadata.get("title")
+    if not title:
+        title = metadata.get("titles")
+
+    return {
+        "title": title,
+        "description": metadata.get("description")
+        or metadata.get("abstract")
+        or metadata.get("abstracts"),
+        "creators": metadata.get("creators") or metadata.get("authors") or [],
+        "doi": metadata.get("doi"),
+        "publication_date": metadata.get("publication_date"),
+    }
+
+
+def load_local_dataset(dataset_root: Path, dataset_name) -> list[dict[str, Any]]:
+    """Load dataset items from local metadata files."""
+    items = []
+    metadata_dir = dataset_root / "metadata"
+    if not metadata_dir.exists():
+        metadata_dir = dataset_root / "Metadata"
+
+    if not metadata_dir.exists():
+        raise FileNotFoundError(
+            f"Could not find metadata directory under {dataset_root}"
+        )
+
+    for meta_path in metadata_dir.rglob("*.json"):
+        metadata = json.loads(meta_path.read_text(encoding="utf-8"))
+        file_paths = metadata.get("file_paths")
+        if not file_paths:
+            continue
+
+        # Use first file listed
+        pdf_path = dataset_root / file_paths[0]
+        pdf_parts = Path(file_paths[0]).parts
+        category = pdf_parts[1] if len(pdf_parts) > 1 else "unknown"
+
+        items.append(
+            {
+                "id": f"{Path(file_paths[0]).name}_{dataset_name}",
+                "input": {
+                    "record_id": meta_path.stem,
+                    "category": category,
+                    "metadata_file": str(meta_path.relative_to(metadata_dir)),
+                    "pdf_path": str(pdf_path),
+                },
+                "expected_output": _expected_output_from_metadata(metadata),
+            }
+        )
+
+    return items
+
+
+def get_or_create_langfuse_dataset(
+    langfuse: Any,
+    dataset_name: str,
+    dataset_items: list[dict[str, Any]],
+) -> Any:
+    """Get existing Langfuse dataset if it exists. If not, create and populate it."""
+    try:
+        langfuse_dataset = langfuse.get_dataset(name=dataset_name)
+        langfuse_dataset_items = list(langfuse_dataset.items)
+        if langfuse_dataset_items:
+            return langfuse_dataset_items
+    except Exception:
+        pass
+    # Populate dataset if it doesn't exist yet in Languse
+    dataset = langfuse.create_dataset(
+        name=dataset_name, description="Evaluation Dataset"
+    )
+    for item in dataset_items:
+        item_id = item.get("id") or item["input"].get("record_id")  # HERE
+
+        langfuse.create_dataset_item(
+            dataset_name=dataset_name,
+            id=item_id,  # HERE
+            input=item["input"],
+            expected_output=item["expected_output"],
+        )
+    dataset = langfuse.get_dataset(name=dataset_name)
+    return list(dataset.items)

--- a/evals/dataset_sync.py
+++ b/evals/dataset_sync.py
@@ -1,0 +1,346 @@
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+"""Fetch the published dataset and overlay newer GitHub objects."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import tempfile
+import zipfile
+from collections.abc import Iterable
+from pathlib import Path, PurePosixPath
+from typing import Any
+from urllib.parse import quote
+
+import requests
+
+REPO = "zenodo/orcha-eval-dataset"
+GITHUB_API = "https://api.github.com"
+GITHUB_RAW = "https://raw.githubusercontent.com"
+GITHUB_MEDIA = "https://media.githubusercontent.com/media"
+ZENODO = "https://zenodo.org"
+USER_AGENT = "orcha-evaluation-dataset-client"
+
+
+class DatasetSyncError(RuntimeError):
+    """Remote dataset or cache state is invalid."""
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _object_path(cache: Path, checksum: str) -> Path:
+    return cache / "objects" / checksum[:2] / checksum
+
+
+def _entries(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    if manifest.get("schema_version") != 1:
+        raise DatasetSyncError(
+            f"Unsupported manifest schema: {manifest.get('schema_version')}"
+        )
+    records = manifest.get("records")
+    if not isinstance(records, dict):
+        raise DatasetSyncError("Manifest records must be an object")
+
+    entries = []
+    paths = set()
+    for record_id, record in records.items():
+        for field in ("document", "metadata"):
+            entry = record.get(field)
+            if not isinstance(entry, dict):
+                raise DatasetSyncError(f"{record_id}: missing {field} entry")
+            relative = PurePosixPath(entry.get("path", ""))
+            if (
+                relative.is_absolute()
+                or ".." in relative.parts
+                or relative.parts[:1] not in (("files",), ("metadata",))
+            ):
+                raise DatasetSyncError(f"{record_id}: invalid path {relative}")
+            checksum = entry.get("sha256")
+            size = entry.get("size")
+            if not isinstance(checksum, str) or not re.fullmatch(
+                r"[0-9a-f]{64}", checksum
+            ):
+                raise DatasetSyncError(f"{record_id}: invalid SHA-256")
+            if not isinstance(size, int) or size < 0:
+                raise DatasetSyncError(f"{record_id}: invalid size")
+            path = relative.as_posix()
+            if path in paths:
+                raise DatasetSyncError(f"Duplicate manifest path: {path}")
+            paths.add(path)
+            entries.append({"path": path, "sha256": checksum, "size": size})
+    return sorted(entries, key=lambda entry: entry["path"])
+
+
+def _headers(token: str | None = None) -> dict[str, str]:
+    headers = {"User-Agent": USER_AGENT}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _get(
+    url: str,
+    *,
+    token: str | None = None,
+    stream: bool = False,
+) -> requests.Response:
+    response = requests.get(
+        url,
+        headers=_headers(token),
+        stream=stream,
+        timeout=(30, 3600),
+    )
+    if response.status_code >= 400:
+        raise DatasetSyncError(
+            f"GET {url} failed with {response.status_code}: {response.text[:1000]}"
+        )
+    return response
+
+
+def _resolve_commit(repo: str, ref: str, token: str | None) -> str:
+    if re.fullmatch(r"[0-9a-f]{40}", ref):
+        return ref
+    response = _get(
+        f"{GITHUB_API}/repos/{repo}/commits/{quote(ref, safe='')}",
+        token=token,
+    )
+    return response.json()["sha"]
+
+
+def _valid_object(path: Path, entry: dict[str, Any]) -> bool:
+    # Objects are hashed before this content-addressed path is created.
+    return path.is_file() and path.stat().st_size == entry["size"]
+
+
+def _store_object(
+    source: Any,
+    cache: Path,
+    entry: dict[str, Any],
+) -> Path:
+    destination = _object_path(cache, entry["sha256"])
+    if _valid_object(destination, entry):
+        return destination
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    digest = hashlib.sha256()
+    size = 0
+    with tempfile.NamedTemporaryFile(dir=destination.parent, delete=False) as target:
+        temporary = Path(target.name)
+        try:
+            while chunk := source.read(1 << 20):
+                target.write(chunk)
+                digest.update(chunk)
+                size += len(chunk)
+        except BaseException:
+            temporary.unlink(missing_ok=True)
+            raise
+
+    if size != entry["size"] or digest.hexdigest() != entry["sha256"]:
+        temporary.unlink(missing_ok=True)
+        raise DatasetSyncError(f"Hash or size mismatch for {entry['path']}")
+    temporary.replace(destination)
+    return destination
+
+
+def _missing(cache: Path, entries: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        entry
+        for entry in entries
+        if not _valid_object(_object_path(cache, entry["sha256"]), entry)
+    ]
+
+
+def _seed_archive(
+    archive_path: Path,
+    manifest_bytes: bytes,
+    cache: Path,
+) -> None:
+    manifest = json.loads(manifest_bytes)
+    entries = _entries(manifest)
+    with zipfile.ZipFile(archive_path) as archive:
+        if archive.read("manifest.json") != manifest_bytes:
+            raise DatasetSyncError("Archive manifest differs from Zenodo manifest")
+        for entry in _missing(cache, entries):
+            try:
+                with archive.open(entry["path"]) as source:
+                    _store_object(source, cache, entry)
+            except KeyError as error:
+                raise DatasetSyncError(f"Archive is missing {entry['path']}") from error
+
+
+def _download_archive(
+    url: str,
+    checksum: str,
+    destination: Path,
+) -> Path:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    response = _get(url, stream=True)
+    digest = hashlib.md5()
+    with tempfile.NamedTemporaryFile(dir=destination.parent, delete=False) as target:
+        temporary = Path(target.name)
+        try:
+            for chunk in response.iter_content(1 << 20):
+                target.write(chunk)
+                digest.update(chunk)
+        except BaseException:
+            temporary.unlink(missing_ok=True)
+            raise
+    if checksum != f"md5:{digest.hexdigest()}":
+        temporary.unlink(missing_ok=True)
+        raise DatasetSyncError("Zenodo archive checksum mismatch")
+    temporary.replace(destination)
+    return destination
+
+
+def _seed_zenodo(
+    cache: Path,
+    state: dict[str, Any],
+    zenodo_base: str,
+) -> None:
+    record_id = state["latest_recid"]
+    response = _get(f"{zenodo_base.rstrip('/')}/api/records/{record_id}/files")
+    remote = {entry["key"]: entry for entry in response.json()["entries"]}
+    try:
+        manifest_remote = remote["manifest.json"]
+        archive_remote = remote[state["archive"]]
+    except KeyError as error:
+        raise DatasetSyncError(f"Zenodo record is missing {error.args[0]}") from error
+
+    published_manifest = _get(manifest_remote["links"]["content"]).content
+    if _sha256_bytes(published_manifest) != state["manifest_sha256"]:
+        raise DatasetSyncError("Zenodo manifest does not match .zenodo-record.json")
+    entries = _entries(json.loads(published_manifest))
+    if not _missing(cache, entries):
+        return
+
+    archive_path = cache / "tmp" / state["archive"]
+    _download_archive(
+        archive_remote["links"]["content"],
+        archive_remote["checksum"],
+        archive_path,
+    )
+    try:
+        _seed_archive(archive_path, published_manifest, cache)
+    finally:
+        archive_path.unlink(missing_ok=True)
+
+
+def _fetch_current_objects(
+    cache: Path,
+    manifest: dict[str, Any],
+    repo: str,
+    commit: str,
+    token: str | None,
+) -> None:
+    for entry in _missing(cache, _entries(manifest)):
+        path = quote(entry["path"], safe="/")
+        base = GITHUB_MEDIA if entry["path"].startswith("files/") else GITHUB_RAW
+        response = _get(f"{base}/{repo}/{commit}/{path}", token=token, stream=True)
+        with response.raw as source:
+            source.decode_content = True
+            _store_object(source, cache, entry)
+
+
+def _materialize(
+    target: Path,
+    cache: Path,
+    manifest: dict[str, Any],
+    provenance: dict[str, Any],
+) -> Path:
+    target.mkdir(parents=True, exist_ok=True)
+    state_path = target / ".dataset-state.json"
+    previous = {}
+    if state_path.exists():
+        previous = json.loads(state_path.read_text(encoding="utf-8"))
+
+    entries = _entries(manifest)
+    current_paths = {entry["path"] for entry in entries}
+    previous_paths = set(previous.get("managed_paths", []))
+    for stale in previous_paths - current_paths:
+        stale_path = target / stale
+        if stale_path.is_symlink():
+            stale_path.unlink()
+
+    for entry in entries:
+        destination = target / entry["path"]
+        source = _object_path(cache, entry["sha256"])
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if destination.is_symlink() and destination.resolve() == source.resolve():
+            continue
+        if destination.is_symlink() and entry["path"] in previous_paths:
+            destination.unlink()
+        if destination.exists() or destination.is_symlink():
+            raise DatasetSyncError(f"Refusing to replace unmanaged file: {destination}")
+        destination.symlink_to(os.path.relpath(source, destination.parent))
+
+    materialized = {**provenance, "managed_paths": sorted(current_paths)}
+    state_path.write_text(json.dumps(materialized, indent=2) + "\n", encoding="utf-8")
+    return target
+
+
+def sync_dataset(
+    *,
+    repo: str = REPO,
+    ref: str = "main",
+    cache: Path | None = None,
+    target: Path | None = None,
+    zenodo_base: str = ZENODO,
+) -> tuple[Path, dict[str, Any]]:
+    """Synchronize one Git commit through the Zenodo-backed object cache."""
+    cache = (
+        cache
+        or Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
+        / "orcha-eval-dataset"
+    )
+    target = target or cache / "dataset"
+    token = os.environ.get("GITHUB_TOKEN")
+    commit = _resolve_commit(repo, ref, token)
+
+    raw_base = f"{GITHUB_RAW}/{repo}/{commit}"
+    manifest_bytes = _get(f"{raw_base}/manifest.json", token=token).content
+    manifest = json.loads(manifest_bytes)
+    _entries(manifest)
+    state = _get(f"{raw_base}/.zenodo-record.json", token=token).json()
+
+    _seed_zenodo(cache, state, zenodo_base)
+    _fetch_current_objects(cache, manifest, repo, commit, token)
+
+    provenance = {
+        "dataset_git_commit": commit,
+        "dataset_manifest_sha256": _sha256_bytes(manifest_bytes),
+        "dataset_repo": repo,
+        "dataset_version": state["version"],
+        "zenodo_doi": state["latest_doi"],
+        "zenodo_record_id": state["latest_recid"],
+    }
+    return _materialize(target, cache, manifest, provenance), provenance
+
+
+def main() -> None:
+    """Run the dataset synchronization CLI."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=REPO)
+    parser.add_argument("--ref", default="main")
+    parser.add_argument("--cache", type=Path)
+    parser.add_argument("--target", type=Path)
+    args = parser.parse_args()
+
+    target, provenance = sync_dataset(
+        repo=args.repo,
+        ref=args.ref,
+        cache=args.cache,
+        target=args.target,
+    )
+    print(f"Dataset ready at {target}")
+    print(json.dumps(provenance, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/evals/evaluators.py
+++ b/evals/evaluators.py
@@ -1,0 +1,415 @@
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+import re
+from difflib import SequenceMatcher
+from typing import Any
+
+from langfuse import Evaluation
+
+
+def norm_name(name: Any) -> str:
+    """Normalize a person name to sorted lowercase tokens."""
+    tokens = re.findall(r"\w+", str(name or "").lower())
+    return " ".join(sorted(tokens))
+
+
+def norm_orcid(orcid: Any) -> str:
+    """Normalize an ORCID to its bare uppercase identifier."""
+    return re.sub(r"[^0-9X]", "", str(orcid or "").upper())
+
+
+def norm_doi(doi: Any) -> str:
+    """Normalize a DOI by removing common prefixes."""
+    doi = str(doi or "").strip().lower()
+    return re.sub(r"^(https?://)?(dx\.)?doi\.org/|^doi:\s*", "", doi)
+
+
+def sym_score(exp_vals: list, pred_vals: list, sim: Any) -> tuple[float, bool]:
+    """Return a symmetric precision/recall score and GT presence."""
+    if not exp_vals:
+        return (1.0 if not pred_vals else 0.0), False
+    if not pred_vals:
+        return 0.0, True
+
+    precision = sum(max(sim(p, e) for e in exp_vals) for p in pred_vals) / len(
+        pred_vals
+    )
+    recall = sum(max(sim(p, e) for p in pred_vals) for e in exp_vals) / len(exp_vals)
+    if precision + recall == 0:
+        return 0.0, True
+    return 2 * precision * recall / (precision + recall), True
+
+
+def align_creators(
+    exp_creators: list, pred_creators: list, threshold: float = 0.8
+) -> dict[int, int]:
+    """Match predicted creators to expected creators by name."""
+    candidates = []
+    for exp_index, expected in enumerate(exp_creators):
+        if not isinstance(expected, dict):
+            continue
+        expected_name = norm_name(expected.get("name"))
+        for pred_index, predicted in enumerate(pred_creators):
+            if not isinstance(predicted, dict):
+                continue
+            score = SequenceMatcher(
+                None, expected_name, norm_name(predicted.get("name"))
+            ).ratio()
+            if score >= threshold:
+                candidates.append((score, exp_index, pred_index))
+
+    matches = {}
+    used_expected = set()
+    used_predicted = set()
+    for _score, exp_index, pred_index in sorted(candidates, reverse=True):
+        if exp_index in used_expected or pred_index in used_predicted:
+            continue
+        used_expected.add(exp_index)
+        used_predicted.add(pred_index)
+        matches[exp_index] = pred_index
+    return matches
+
+
+def indexed_score(
+    exp_creators: list,
+    pred_creators: list,
+    matches: dict[int, int],
+    get_vals: Any,
+    sim: Any,
+) -> dict[str, Any]:
+    """Score an attribute after creators have been matched by name."""
+    exp_has = [
+        index
+        for index, creator in enumerate(exp_creators)
+        if isinstance(creator, dict) and get_vals(creator)
+    ]
+    pred_has = [
+        index
+        for index, creator in enumerate(pred_creators)
+        if isinstance(creator, dict) and get_vals(creator)
+    ]
+    predicted = [get_vals(pred_creators[index]) for index in pred_has]
+    if not exp_has:
+        return {
+            "expected": [],
+            "predicted": predicted,
+            "score": 1.0 if not pred_has else 0.0,
+            "matched": not pred_has,
+            "gt_present": False,
+        }
+
+    pred_to_exp = {pred_index: exp_index for exp_index, pred_index in matches.items()}
+
+    def pair(exp_index: int, pred_index: int) -> float:
+        return sym_score(
+            get_vals(exp_creators[exp_index]),
+            get_vals(pred_creators[pred_index]),
+            sim,
+        )[0]
+
+    recall = sum(
+        pair(exp_index, matches[exp_index]) if exp_index in matches else 0.0
+        for exp_index in exp_has
+    ) / len(exp_has)
+    precision = (
+        sum(
+            pair(pred_to_exp[pred_index], pred_index)
+            if pred_index in pred_to_exp
+            else 0.0
+            for pred_index in pred_has
+        )
+        / len(pred_has)
+        if pred_has
+        else 0.0
+    )
+    score = 2 * precision * recall / (precision + recall) if precision + recall else 0.0
+    return {
+        "expected": [get_vals(exp_creators[index]) for index in exp_has],
+        "predicted": predicted,
+        "score": score,
+        "matched": score == 1.0,
+        "gt_present": True,
+    }
+
+
+class Evaluator:
+    """Compare predicted metadata with expected metadata."""
+
+    def __init__(self, item: dict[str, Any], predicted: dict[str, Any]) -> None:
+        """Store expected and predicted metadata for later comparison."""
+        self.exp = item["expected_output"]
+        self.pred = predicted
+
+    def _text_eval(self, exp_val: Any, pred_val: Any) -> dict[str, Any]:
+        """Return the best match against one or more expected strings."""
+        if isinstance(exp_val, list):
+            candidates = [
+                next(iter(value.values())) if isinstance(value, dict) else value
+                for value in exp_val
+            ]
+        else:
+            candidates = [exp_val]
+        candidates = [candidate for candidate in candidates if candidate]
+
+        gt_present = bool(candidates)
+        if gt_present:
+            score = max(
+                SequenceMatcher(None, str(candidate), str(pred_val or "")).ratio()
+                for candidate in candidates
+            )
+        else:
+            score = 1.0 if not pred_val else 0.0
+
+        return {
+            "expected": candidates,
+            "predicted": pred_val,
+            "score": score,
+            "matched": score == 1.0,
+            "gt_present": gt_present,
+        }
+
+    def title_eval(self) -> dict[str, Any]:
+        """Compare the predicted title with the expected title."""
+        return self._text_eval(self.exp.get("title"), self.pred.get("title"))
+
+    def description_eval(self) -> dict[str, Any]:
+        """Compare the predicted description with the expected description."""
+        return self._text_eval(
+            self.exp.get("description"), self.pred.get("description")
+        )
+
+    def doi_eval(self) -> dict[str, Any]:
+        """Compare DOI identifiers exactly after normalization."""
+        exp_doi = self.exp.get("doi")
+        pred_doi = self.pred.get("doi")
+        exp_norm = norm_doi(exp_doi)
+        pred_norm = norm_doi(pred_doi)
+        gt_present = bool(exp_norm)
+        score = (
+            (1.0 if pred_norm == exp_norm else 0.0)
+            if gt_present
+            else (1.0 if not pred_norm else 0.0)
+        )
+
+        return {
+            "expected": exp_doi,
+            "predicted": pred_doi,
+            "score": score,
+            "matched": score == 1.0,
+            "gt_present": gt_present,
+        }
+
+    def publication_date_eval(self) -> dict[str, Any]:
+        """Compare a publication date at the ground truth's precision."""
+        exp_date = self.exp.get("publication_date")
+        pred_date = self.pred.get("publication_date")
+        exp_str = str(exp_date or "").strip()
+        pred_str = str(pred_date or "").strip()
+        gt_present = bool(exp_str)
+        score = (
+            SequenceMatcher(None, exp_str, pred_str[: len(exp_str)]).ratio()
+            if gt_present
+            else (1.0 if not pred_str else 0.0)
+        )
+        return {
+            "expected": exp_date,
+            "predicted": pred_date,
+            "score": score,
+            "matched": score == 1.0,
+            "gt_present": gt_present,
+        }
+
+    def creators_eval(self) -> dict[str, dict[str, Any]]:
+        """Compare predicted creator names, ORCIDs, and affiliations."""
+        exp_creators = self.exp.get("creators", [])
+        pred_creators = self.pred.get("creators", [])
+
+        results: dict[str, dict[str, Any]] = {}
+
+        similarities = {
+            "name": lambda p, e: SequenceMatcher(
+                None, norm_name(p), norm_name(e)
+            ).ratio(),
+            "orcid": lambda p, e: 1.0 if norm_orcid(p) == norm_orcid(e) else 0.0,
+        }
+        for field in ["name", "orcid"]:
+            exp_vals = [
+                c.get(field)
+                for c in exp_creators
+                if isinstance(c, dict) and c.get(field)
+            ]
+            pred_vals = [
+                c.get(field)
+                for c in pred_creators
+                if isinstance(c, dict) and c.get(field)
+            ]
+
+            score, gt_present = sym_score(exp_vals, pred_vals, similarities[field])
+
+            results[f"creators_{field}"] = {
+                "expected": exp_vals,
+                "predicted": pred_vals,
+                "score": score,
+                "matched": score == 1.0,
+                "gt_present": gt_present,
+            }
+
+        # Evaluate affiliation
+        exp_affiliations = []
+        for c in exp_creators:
+            if isinstance(c, dict) and c.get("affiliation"):
+                for aff in c["affiliation"]:
+                    if isinstance(aff, dict) and aff.get("name"):
+                        exp_affiliations.append(aff["name"])
+
+        pred_affiliations = []
+        for c in pred_creators:
+            if isinstance(c, dict) and c.get("affiliation"):
+                for aff in c["affiliation"]:
+                    if isinstance(aff, dict) and aff.get("name"):
+                        pred_affiliations.append(aff["name"])
+
+        score, gt_present = sym_score(
+            exp_affiliations,
+            pred_affiliations,
+            lambda p, e: SequenceMatcher(
+                None, str(p or "").lower(), str(e or "").lower()
+            ).ratio(),
+        )
+
+        results["creators_affiliation"] = {
+            "expected": exp_affiliations,
+            "predicted": pred_affiliations,
+            "score": score,
+            "matched": score == 1.0,
+            "gt_present": gt_present,
+        }
+
+        matches = align_creators(exp_creators, pred_creators)
+
+        def affiliations(creator: dict) -> list:
+            return [
+                affiliation["name"]
+                for affiliation in creator.get("affiliation") or []
+                if isinstance(affiliation, dict) and affiliation.get("name")
+            ]
+
+        def orcids(creator: dict) -> list:
+            return [creator["orcid"]] if creator.get("orcid") else []
+
+        results["creators_affiliation_indexed"] = indexed_score(
+            exp_creators,
+            pred_creators,
+            matches,
+            affiliations,
+            lambda p, e: SequenceMatcher(
+                None, str(p or "").lower(), str(e or "").lower()
+            ).ratio(),
+        )
+        results["creators_orcid_indexed"] = indexed_score(
+            exp_creators,
+            pred_creators,
+            matches,
+            orcids,
+            lambda p, e: 1.0 if norm_orcid(p) == norm_orcid(e) else 0.0,
+        )
+
+        return results
+
+    def evaluate(self) -> dict[str, dict[str, Any]]:
+        """Run all metadata comparisons and return the combined results."""
+        return {
+            "title": self.title_eval(),
+            "description": self.description_eval(),
+            "doi": self.doi_eval(),
+            "publication_date": self.publication_date_eval(),
+            **self.creators_eval(),
+        }
+
+
+def build_comparison_payload(
+    predicted_output: dict[str, Any],
+    expected_output: dict[str, Any],
+) -> dict[str, Any]:
+    """Build comparison data using the Evaluator class."""
+    evaluator = Evaluator({"expected_output": expected_output}, predicted_output)
+    comparison = evaluator.evaluate()
+
+    diagnostic_only = {"creators_orcid", "creators_affiliation"}
+    headline = {
+        name: field for name, field in comparison.items() if name not in diagnostic_only
+    }
+    gt_fields = [field for field in headline.values() if field["gt_present"]]
+    scored = gt_fields or list(headline.values())
+
+    return {
+        "average_score": round(
+            sum(field["score"] for field in scored) / len(scored), 4
+        ),
+        "mismatch_count": sum(not field["matched"] for field in gt_fields),
+        "field_count": len(headline),
+        "gt_field_count": len(gt_fields),
+        "spurious_count": sum(
+            1
+            for field in headline.values()
+            if not field["gt_present"] and field["score"] < 1.0
+        ),
+        "fields": comparison,
+    }
+
+
+def item_summary_evaluator(
+    output: dict[str, Any],
+    **kwargs: Any,
+) -> list[Evaluation]:
+    """Builds field-level and summary evaluations for Langfuse tracking."""
+    comparison = output["comparison"]
+    evals: list[Evaluation] = []
+
+    for field, field_row in comparison["fields"].items():
+        evals.append(
+            Evaluation(
+                name=f"{field}_score",
+                value=field_row["score"],
+                metadata={
+                    "expected": field_row["expected"],
+                    "predicted": field_row["predicted"],
+                    "matched": field_row["matched"],
+                },
+            )
+        )
+
+    summary_score = float(comparison.get("average_score", 0.0))
+    mismatch_count = int(comparison.get("mismatch_count", 0))
+    field_count = int(comparison.get("field_count", 0))
+
+    evals.append(
+        Evaluation(
+            name="item_summary",
+            value=summary_score,
+            metadata={
+                "mismatch_count": mismatch_count,
+                "field_count": field_count,
+            },
+        )
+    )
+
+    return evals
+
+
+def average_score_evaluator(item_results: list[Any], **kwargs: Any) -> Evaluation:
+    """Aggregates scores across all items in the run."""
+    all_scores = [
+        evaluation.value
+        for result in item_results
+        for evaluation in result.evaluations
+        if evaluation.name == "item_summary"
+    ]
+
+    avg = round(sum(all_scores) / len(all_scores), 2) if all_scores else 0.0
+
+    return Evaluation(
+        name="run_average_score",
+        value=avg,
+    )

--- a/evals/extractors/__init__.py
+++ b/evals/extractors/__init__.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+"""PDF extraction modules."""
+
+from .pdfplumber import PdfplumberExtractor
+from .pymupdf import PymupdfExtractor
+
+
+def get_extractor(extractor: str = "pdfplumber"):
+    """Get an extractor instance by type.
+
+    Args:
+        extractor: Either "pdfplumber" or "pymupdf"
+
+    Returns:
+        Extractor instance
+
+    Raises:
+        ValueError: If unknown extractor type is specified
+    """
+    if extractor == "pdfplumber":
+        return PdfplumberExtractor()
+    elif extractor == "pymupdf":
+        return PymupdfExtractor()
+    else:
+        raise ValueError(
+            f"Unknown extractor: {extractor}. Supported extractors: pdfplumber, pymupdf"
+        )

--- a/evals/extractors/base.py
+++ b/evals/extractors/base.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+"""Base class for PDF extractors."""
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional
+
+
+class BaseExtractor(ABC):
+    """Base class for PDF extractors."""
+
+    @abstractmethod
+    def extract(
+        self, pdf_bytes: bytes, pages: Optional[List[int]] = None
+    ) -> Dict[str, Any]:
+        """Extract content from PDF.
+
+        Args:
+            pdf_bytes: PDF file content as bytes.
+            pages: Optional list of pages to extract. Positive numbers are 1-based,
+                   negative numbers count from end (-1 = last page).
+                   Example: [1, 2, 3, -2, -1] = first 3 + last 2 pages.
+
+        Returns:
+            Dictionary containing extracted content:
+            Required keys:
+            - full_text: Extracted text content
+            - page_count: Total number of pages in the document
+            - pages_extracted: List of page numbers actually extracted (1-indexed)
+            - extra: Dict containing tool-specific extraction data
+
+        """
+        pass
+
+    def _classify_link(self, url: str) -> str:
+        """Classify hyperlink type."""
+        url_lower = url.lower()
+        if "orcid.org" in url_lower:
+            return "orcid"
+        if "doi.org" in url_lower or url_lower.startswith("10."):
+            return "doi"
+        if url_lower.startswith("mailto:"):
+            return "email"
+        if "github.com" in url_lower or "gitlab.com" in url_lower:
+            return "github"
+        return "other"

--- a/evals/extractors/errors.py
+++ b/evals/extractors/errors.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+"""Custom exceptions for PDF extractors."""
+
+
+class InvalidPageSelectionError(ValueError):
+    """Raised when a requested page selection is invalid for a PDF."""

--- a/evals/extractors/pdfplumber.py
+++ b/evals/extractors/pdfplumber.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+"""PDFPlumber-based PDF extractor."""
+
+from io import BytesIO
+from typing import Any, Dict, List, Optional
+
+from .base import BaseExtractor
+from .utils import resolve_pages
+
+
+class PdfplumberExtractor(BaseExtractor):
+    """Extract content using pdfplumber."""
+
+    def extract(
+        self, pdf_bytes: bytes, pages: Optional[List[int]] = None
+    ) -> Dict[str, Any]:
+        """Extract content from PDF using pdfplumber."""
+        import pdfplumber
+
+        full_text_parts = []
+        tables = []
+        hyperlinks = []
+
+        with pdfplumber.open(BytesIO(pdf_bytes)) as pdf:
+            page_count = len(pdf.pages)
+
+            # Resolve page selection
+            resolved_pages = resolve_pages(pages, page_count)
+            page_indices = resolved_pages if resolved_pages else range(page_count)
+
+            for page_num in page_indices:
+                page = pdf.pages[page_num]
+                # Extract text with x_tolerance=2 to better detect word boundaries
+                # Default x_tolerance=3 merges words like "PhilipBull" that have gaps
+                text = page.extract_text(x_tolerance=2) or ""
+                full_text_parts.append(text)
+
+                # Extract tables
+                page_tables = page.extract_tables()
+                for table in page_tables:
+                    if table:
+                        tables.append(
+                            {
+                                "page": page_num + 1,
+                                "rows": len(table),
+                                "data": table,
+                            }
+                        )
+
+                # Extract hyperlinks (annotations with URI)
+                if page.annots:
+                    for annot in page.annots:
+                        uri = annot.get("uri")
+                        if uri:
+                            link_type = self._classify_link(uri)
+                            hyperlinks.append(
+                                {
+                                    "url": uri,
+                                    "page": page_num + 1,
+                                    "type": link_type,
+                                }
+                            )
+
+        # Build full text including table content
+        full_text = "\n\n".join(full_text_parts)
+
+        # Add table content to full_text for searchability
+        for table in tables:
+            for row in table["data"]:
+                if row:
+                    row_text = " | ".join(str(cell) if cell else "" for cell in row)
+                    full_text += "\n" + row_text
+
+        # Extract ORCID IDs from hyperlinks and add to full_text
+        # This makes ORCIDs discoverable even when they're only in link URLs
+        # (not visible text)
+        orcid_ids = [
+            self._extract_orcid_id(h["url"]) for h in hyperlinks if h["type"] == "orcid"
+        ]
+        orcid_ids = [oid for oid in orcid_ids if oid]  # filter None
+        if orcid_ids:
+            full_text += "\n\nORCID IDs from hyperlinks: " + " ".join(orcid_ids)
+
+        return {
+            "full_text": full_text,
+            "page_count": page_count,
+            "pages_extracted": (
+                [i + 1 for i in page_indices]
+                if resolved_pages
+                else list(range(1, page_count + 1))
+            ),
+            "extra": {
+                "hyperlinks": hyperlinks,
+                "tables": tables,
+            },
+        }
+
+    def _extract_orcid_id(self, url: str) -> str | None:
+        """Extract ORCID ID from an orcid.org URL."""
+        import re
+
+        match = re.search(r"orcid\.org/(\d{4}-\d{4}-\d{4}-\d{3}[\dX])", url)
+        return match.group(1) if match else None

--- a/evals/extractors/pymupdf.py
+++ b/evals/extractors/pymupdf.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+"""PyMuPDF-based PDF extractor."""
+
+from typing import Any, Dict, List, Optional
+
+from .base import BaseExtractor
+from .utils import resolve_pages
+
+
+class PymupdfExtractor(BaseExtractor):
+    """Extract metadata and content using PyMuPDF/pymupdf4llm."""
+
+    def extract(
+        self, pdf_bytes: bytes, pages: Optional[List[int]] = None
+    ) -> Dict[str, Any]:
+        """Extract content from PDF using Pymupdf."""
+        # Import inside function to avoid PyMuPDF initialization issues in
+        # temporal worker. PyMuPDF's C++ bindings have documented incompatibility with
+        # threading/worker environments that cause "AttributeError: 'FzDocument' object
+        # has no attribute 'super'" when imported at module level.
+        # See: https://pymupdf.readthedocs.io/en/latest/recipes-multiprocessing.html
+        import pymupdf
+        import pymupdf4llm
+
+        # Open PDF from bytes using PyMuPDF's stream interface
+        doc = pymupdf.open(stream=pdf_bytes, filetype="pdf")
+        page_count = len(doc)
+
+        # PDF embedded metadata (often sparse)
+        pdf_meta = doc.metadata or {}
+
+        # Resolve page selection
+        resolved_pages = resolve_pages(pages, page_count)
+
+        # Extract markdown
+        markdown = pymupdf4llm.to_markdown(doc, pages=resolved_pages)
+
+        # Extract hyperlinks
+        hyperlinks = []
+        page_indices = resolved_pages if resolved_pages else range(page_count)
+        for page_idx in page_indices:
+            page = doc[page_idx]
+            for link in page.get_links():
+                uri = link.get("uri")
+                if uri:
+                    link_type = self._classify_link(uri)
+                    hyperlinks.append(
+                        {
+                            "url": uri,
+                            "page": page_idx + 1,
+                            "type": link_type,
+                        }
+                    )
+
+        doc.close()
+
+        return {
+            "full_text": markdown,
+            "page_count": page_count,
+            "pages_extracted": (
+                [i + 1 for i in page_indices]
+                if resolved_pages
+                else list(range(1, page_count + 1))
+            ),
+            "extra": {
+                "hyperlinks": hyperlinks,
+                "pdf_metadata": pdf_meta,
+            },
+        }

--- a/evals/extractors/utils.py
+++ b/evals/extractors/utils.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+"""Utility functions for PDF extractors."""
+
+from typing import List, Optional
+
+from .errors import InvalidPageSelectionError
+
+
+def resolve_pages(pages: Optional[List[int]], total_pages: int) -> Optional[List[int]]:
+    """Resolve page list with negative indices to 0-based page numbers."""
+    if pages is None:
+        return None
+
+    if total_pages < 1:
+        raise InvalidPageSelectionError("Cannot select pages from a PDF with no pages")
+
+    resolved = set()
+    for p in pages:
+        if p == 0:
+            raise InvalidPageSelectionError(
+                "Page numbers are 1-based; 0 is not allowed"
+            )
+
+        if p > 0:
+            if p > total_pages:
+                raise InvalidPageSelectionError(
+                    f"Page {p} is out of range for a PDF with {total_pages} pages"
+                )
+            idx = p - 1
+        else:
+            if p < -total_pages:
+                raise InvalidPageSelectionError(
+                    f"Page {p} is out of range for a PDF with {total_pages} pages"
+                )
+            idx = total_pages + p
+
+        resolved.add(idx)
+    return sorted(resolved)

--- a/evals/models.py
+++ b/evals/models.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+"""Pydantic models and LLM setup for metadata extraction."""
+
+import os
+
+from pydantic import BaseModel, Field
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.litellm import LiteLLMProvider
+from pydantic_ai.providers.ollama import OllamaProvider
+
+
+class Affiliation(BaseModel):
+    """Affiliation model."""
+
+    name: str
+    ror: str | None = None
+
+
+class Creator(BaseModel):
+    """Creator model for structured output."""
+
+    name: str
+    affiliation: list[Affiliation] | None = None
+    orcid: str | None = None
+
+
+class MetadataResult(BaseModel):
+    """Metadata result schema for evals."""
+
+    title: str | None = None
+    description: str | None = None
+    creators: list[Creator] = Field(default_factory=list)
+    doi: str | None = None
+    publication_date: str | None = None
+
+
+def parse_llm(llm: str) -> tuple[str, str]:
+    """Parse LLM environment variable into provider and model name."""
+    provider, sep, model_name = llm.partition("/")
+    if not sep:
+        raise ValueError("Invalid LLM; expected '<provider>/<model>'")
+    provider = provider.strip().lower()
+    model_name = model_name.strip()
+    if provider not in {"litellm", "openai", "ollama"}:
+        raise ValueError("Invalid LLM; provider must be 'litellm' or 'ollama'")
+    if not model_name:
+        raise ValueError("Invalid LLM; model name is missing")
+    return provider, model_name
+
+
+def create_model() -> OpenAIChatModel:
+    """Create an OpenAI-compatible chat model from settings."""
+    provider_name, model_name = parse_llm(os.getenv("LLM"))
+
+    if provider_name == "ollama":
+        provider = OllamaProvider(
+            base_url=os.getenv("OLLAMA_API_BASE"),
+            api_key=os.getenv("OLLAMA_API_KEY"),
+        )
+    else:
+        provider = LiteLLMProvider(
+            api_base=os.getenv("LITELLM_API_BASE"),
+            api_key=os.getenv("LITELLM_API_KEY"),
+        )
+
+    return OpenAIChatModel(model_name=model_name, provider=provider)

--- a/evals/prompts.py
+++ b/evals/prompts.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+"""Langfuse prompt management."""
+
+from pathlib import Path
+from typing import Any
+
+PROMPTS_DIR = Path("evals/prompts")
+
+
+def sync_extraction_prompt(
+    langfuse: Any, prompt_name: str = "medium"
+) -> dict[str, Any]:
+    """Create or version the extraction prompt in Langfuse and return its reference."""
+    instructions = (PROMPTS_DIR / f"{prompt_name}.txt").read_text()
+
+    created = langfuse.create_prompt(
+        name=prompt_name,
+        prompt=instructions,
+        commit_message="Sync prompt from eval runner",
+        type="text",
+    )
+
+    return {
+        "name": prompt_name,
+        "version": getattr(created, "version", None),
+        "text": instructions,
+    }

--- a/evals/prompts/advanced.txt
+++ b/evals/prompts/advanced.txt
@@ -1,0 +1,45 @@
+You extract scientific-document metadata from raw document text.
+
+Return these fields:
+- title: string or null
+- description/abstract: string or null
+- creators: list of objects with name, affiliation, orcid
+- doi: string or null
+- publication_date: string or null
+
+Rules:
+- Use only information explicitly present in the text.
+- Extract the full description/abstract if available.
+- Do not guess missing values.
+- Return creators as a list of creator objects.
+- Prefer the document title over section headings.
+- Distinguish between document authors and group members:
+  * Authors are who wrote/created the document
+  * Ignore lists explicitly labeled such as "members of", "panel members",
+  "committee members","contributors to"
+  * If a section lists members of a collaboration/committee, those are NOT authors
+  unless they also appear as document creators
+- For publication_date: Look for dates in formats like "Accepted: 16 March 2026".
+- Parse publication dates to YYYY-MM-DD format (e.g., "2026-03-16").If only year
+is available, use YYYY format.
+- Return the DOI as the DOI string only.
+
+Handling affiliations and ORCIDs:
+- If authors have superscript markers (a,b,c,d,etc.) or mathematical symbols next to
+their names, use those to map to
+  the corresponding affiliations listed below.
+- Affiliation markers may appear in different formats:
+  * Separated from text: "a Department of Physics"
+  * Attached directly: "aDepartment of Physics" or "𝑎Department of Physics"
+  (mathematical alphanumeric symbols)
+  * In both cases, match the marker to the affiliation starting with that same marker
+- Multiple affiliations per author should be kept as a single string, separated by
+  semicolons (e.g. "University A; Institute B").
+- If ORCIDs are listed separately (e.g. "ORCID IDs: ..."),
+  assign them to authors in order:
+  * The first ORCID goes to the first author, second ORCID to second author, etc.
+  * If there are fewer ORCIDs than authors, use null for authors without an ORCID.
+  * The creators list must have exactly as many ORCID values as there are authors
+  (some may be null).
+- If ORCID cannot be reliably matched to a specific author, set to null for that author.
+

--- a/evals/prompts/medium.txt
+++ b/evals/prompts/medium.txt
@@ -1,0 +1,22 @@
+You extract metadata from document text.
+
+Return these fields:
+- title
+- description
+- creators
+- doi
+- publication_date
+
+Rules:
+- Use only text that is clearly present.
+- If something is missing, leave it null.
+- Return creators as a list of objects.
+- Each creator object must use this shape: {"name": string, "affiliation": [{"name": string, "ror": null}], "orcid": string|null}.
+- Keep the exact capitalization you see in the text.
+- Extract the DOI when it appears as `doi: ...`, `DOI: ...`, or a `doi.org/...` URL.
+- Return the DOI as only the DOI string, without the `https://doi.org/` prefix.
+- When authors have superscript numbers or symbols, map them to the matching entries in an `AFFILIATIONS` section.
+- When the author line contains marker letters or numbers and the affiliations are listed below with the same markers, use those markers to build each creator's affiliation list.
+- If ORCID IDs are listed separately, assign them to creators only when the correspondence is explicit from the text or clearly follows author order.
+- For each creator, return `affiliation` as a list of objects with `name` and `ror`.
+- Return publication_date as YYYY-MM-DD, or YYYY-MM or YYYY if only partial date is known.

--- a/evals/run.py
+++ b/evals/run.py
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+"""Langfuse experiments runner using the SDK Experiments API."""
+
+import argparse
+import asyncio
+import os
+from io import BytesIO
+from pathlib import Path
+
+import pdfplumber
+from dataset import (
+    get_or_create_langfuse_dataset,
+    load_local_dataset,
+)
+from evaluators import (
+    average_score_evaluator,
+    build_comparison_payload,
+    item_summary_evaluator,
+)
+from extractors import get_extractor
+from langfuse import get_client
+from models import MetadataResult, create_model
+from prompts import sync_extraction_prompt
+from pydantic_ai import Agent
+
+DATASET_ROOT = Path("full-dataset")
+DATASET_NAME = "results-with-all-tools"
+EXPERIMENT_NAME = "results-with-all-tools"
+
+
+def extract_text(pdf_path: Path, extractor_name: str, pages: list[int] | None = None):
+    """Read a PDF file and extract text with the configured extractor.
+
+    If requested pages are out of range, filters to available pages only.
+    """
+    extractor = get_extractor(extractor_name)
+    pdf_bytes = pdf_path.read_bytes()
+
+    # If pages are specified, filter them
+    if pages:
+        with pdfplumber.open(BytesIO(pdf_bytes)) as pdf:
+            page_count = len(pdf.pages)
+            # Filter to pages that actually exist (1-based indexing)
+            valid_pages = [p for p in pages if 0 < p <= page_count]
+            if len(valid_pages) < len(pages):
+                # If some pages are invalid, use only the valid ones
+                return extractor.extract(pdf_bytes, pages=valid_pages)["full_text"]
+    return extractor.extract(pdf_bytes, pages=pages)["full_text"]
+
+
+def save_extracted_text(text: str, record_id: str, dataset_root: Path) -> None:
+    """Save extracted text to a file in the extracted_text directory for inspection."""
+    extracted_dir = dataset_root / "extracted_text"
+    extracted_dir.mkdir(parents=True, exist_ok=True)
+
+    output_path = extracted_dir / f"{record_id}.txt"
+    output_path.write_text(text, encoding="utf-8")
+
+
+async def _run_agent(agent: Agent, document_text: str) -> MetadataResult:
+    """Run the extraction agent on document text."""
+    max_retries = 5
+    for attempt in range(max_retries):
+        try:
+            result = await agent.run(document_text)
+            return result.output
+        except Exception as exc:
+            error_str = str(exc)
+            is_retryable = (
+                "429" in error_str
+                or "500" in error_str
+                or "Connection error" in error_str
+            )
+            if is_retryable and attempt < max_retries - 1:
+                wait_time = 2**attempt
+                print(
+                    f"  Retry attempt {attempt + 1}/{max_retries - 1} "
+                    f"after {wait_time}s..."
+                )
+                await asyncio.sleep(wait_time)
+            else:
+                raise
+
+
+async def extraction_task(dataset_item, agent: Agent, extractor: str = "pdfplumber"):
+    """Extract text, run the agent, and build evaluator comparison data."""
+    input_data = dataset_item.get("input")
+    pdf_path = Path(input_data.get("pdf_path"))
+    expected = dataset_item.get("expected_output")
+
+    # Extract text from pdf
+    text = extract_text(pdf_path, extractor, [1, 2])
+
+    # Run model
+    output = await _run_agent(agent, text)
+    output_dict = output.model_dump(mode="json")
+    output_dict["comparison"] = build_comparison_payload(output_dict, expected)
+
+    return {
+        "pdf_filename": pdf_path.name,
+        "comparison": output_dict["comparison"],
+    }
+
+
+async def run(
+    extractor: str = "pdfplumber",
+    prompt_name: str = "medium",
+    run_name: str | None = None,
+):
+    """Run extraction and evaluation experiment."""
+    items = load_local_dataset(DATASET_ROOT, DATASET_NAME)
+
+    client = get_client()
+    prompt_ref = sync_extraction_prompt(client, prompt_name)
+
+    dataset_items = get_or_create_langfuse_dataset(
+        client,
+        DATASET_NAME,
+        items,
+    )
+
+    agent = Agent(
+        model=create_model(),
+        instructions=prompt_ref["text"],
+        output_type=MetadataResult,
+    )
+
+    async def task(item):
+        return await extraction_task(
+            dataset_item={"input": item.input, "expected_output": item.expected_output},
+            agent=agent,
+            extractor=extractor,
+        )
+
+    result = client.run_experiment(
+        name=run_name or EXPERIMENT_NAME,
+        description="Extract and evaluate document metadata",
+        data=dataset_items,
+        metadata={
+            "dataset_name": DATASET_NAME,
+            "model": os.getenv("LLM"),
+            "extractor": extractor,
+            "prompt_name": prompt_ref["name"],
+            "prompt_version": str(prompt_ref.get("version")),
+            "pages": "1,2",
+        },
+        task=task,
+        evaluators=[item_summary_evaluator],
+        run_evaluators=[average_score_evaluator],
+    )
+
+    print(result.format())
+    return result
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run metadata extraction experiment.")
+    parser.add_argument(
+        "--model", default=os.getenv("LLM"), help="LLM model, e.g. litellm/gpt-4o"
+    )
+    parser.add_argument(
+        "--extractor", default="pdfplumber", help="PDF extractor (default: pdfplumber)"
+    )
+    parser.add_argument(
+        "--prompt", default="medium", help="Prompt name (default: medium)"
+    )
+    args = parser.parse_args()
+
+    if args.model:
+        os.environ["LLM"] = args.model
+
+    asyncio.run(run(extractor=args.extractor, prompt_name=args.prompt))

--- a/evals/sweep.py
+++ b/evals/sweep.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+"""Run run.py across combinations of models, extractors, and prompts."""
+
+import asyncio
+import csv
+import json
+import os
+from pathlib import Path
+
+from run import run
+
+RESULTS_DIR = Path("evals/sweep_results")
+
+MODELS = ["litellm/openai/gpt-oss-20b"]
+
+EXTRACTORS = ["pdfplumber", "pymupdf"]
+
+PROMPTS = ["medium"]
+
+
+def to_jsonable(obj):
+    """Best-effort conversion of a result object to plain JSON-safe data."""
+    if hasattr(obj, "model_dump"):  # pydantic v2
+        return obj.model_dump(mode="json")
+    if hasattr(obj, "dict"):  # pydantic v1
+        return obj.dict()
+    if hasattr(obj, "__dict__"):
+        return {k: to_jsonable(v) for k, v in vars(obj).items()}
+    if isinstance(obj, (list, tuple)):
+        return [to_jsonable(v) for v in obj]
+    if isinstance(obj, dict):
+        return {k: to_jsonable(v) for k, v in obj.items()}
+    return obj  # str, int, float, bool, None
+
+
+def flatten_item_rows(run_name, model, extractor, prompt, result_data):
+    """Pull out one row per dataset item, with whatever fields are present."""
+    rows = []
+    items = result_data.get("item_results") or result_data.get("items") or []
+    for item in items:
+        item = to_jsonable(item) if not isinstance(item, dict) else item
+        output = item.get("output") or {}
+
+        row = {
+            "run_name": run_name,
+            "model": model,
+            "extractor": extractor,
+            "prompt": prompt,
+            "item_id": item.get("id") or item.get("item_id"),
+            "pdf_filename": output.get("pdf_filename")
+            if isinstance(output, dict)
+            else None,
+        }
+        scores = item.get("scores") or item.get("evaluations") or []
+        for score in scores:
+            score = to_jsonable(score) if not isinstance(score, dict) else score
+            name = score.get("name", "score")
+            row[f"score__{name}"] = score.get("value")
+        comparison = output.get("comparison") if isinstance(output, dict) else None
+        if comparison:
+            for k, v in comparison.items():
+                row[f"comparison__{k}"] = v
+        rows.append(row)
+    return rows
+
+
+async def run_sweep():
+    """Run the configured evaluation sweep across models and extractors."""
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    all_item_rows = []
+
+    for model in MODELS:
+        for extractor in EXTRACTORS:
+            for prompt in PROMPTS:
+                os.environ["LLM"] = model
+                run_name = f"{model.replace('/', '_')}__{extractor}__{prompt}"
+                print(f"\n=== Running {run_name} ===")
+
+                try:
+                    result = await run(
+                        extractor=extractor,
+                        prompt_name=prompt,
+                        run_name=run_name,
+                    )
+                    result_data = to_jsonable(result)
+
+                    # Save full raw result as JSON (everything Langfuse gave us)
+                    json_path = RESULTS_DIR / f"{run_name}.json"
+                    json_path.write_text(json.dumps(result_data, indent=2, default=str))
+
+                    # Try to flatten item-level rows for the combined CSV
+                    all_item_rows.extend(
+                        flatten_item_rows(
+                            run_name, model, extractor, prompt, result_data
+                        )
+                    )
+
+                except Exception as exc:
+                    print(f"  ERROR: {exc}")
+                    error_path = RESULTS_DIR / f"{run_name}_error.txt"
+                    error_path.write_text(str(exc))
+
+    # Write combined CSV across all runs, if we got any rows
+    if all_item_rows:
+        all_keys = sorted({k for row in all_item_rows for k in row})
+        csv_path = RESULTS_DIR / "all_items.csv"
+        with open(csv_path, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=all_keys)
+            writer.writeheader()
+            writer.writerows(all_item_rows)
+        print(f"\nWrote {len(all_item_rows)} item rows to {csv_path}")
+    else:
+        print("\nNo item-level rows extracted — check the JSON files and result shape.")
+
+    print(f"Full per-run JSON dumps in {RESULTS_DIR}")
+
+
+if __name__ == "__main__":
+    asyncio.run(run_sweep())

--- a/evals/test_evaluators.py
+++ b/evals/test_evaluators.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+import pytest
+
+from evals.evaluators import Evaluator, build_comparison_payload
+
+
+def test_creator_score_penalizes_missing_expected_authors():
+    """Missing expected authors reduce the creator score."""
+    result = Evaluator(
+        {"expected_output": {"creators": [{"name": "Alice"}, {"name": "Zorro"}]}},
+        {"creators": [{"name": "Alice"}]},
+    ).creators_eval()
+
+    assert result["creators_name"]["score"] == pytest.approx(2 / 3)
+
+
+@pytest.mark.parametrize(
+    ("predicted", "score"),
+    [
+        ("https://doi.org/10.1234/example.5678", 1.0),
+        ("10.1234/example.5679", 0.0),
+    ],
+)
+def test_doi_score_requires_an_exact_normalized_identifier(predicted, score):
+    """DOIs match exactly after common prefixes are removed."""
+    result = Evaluator(
+        {"expected_output": {"doi": "10.1234/example.5678"}},
+        {"doi": predicted},
+    ).doi_eval()
+
+    assert result["score"] == score
+
+
+def test_publication_date_uses_ground_truth_precision():
+    """Extra date precision does not reduce the score."""
+    result = Evaluator(
+        {"expected_output": {"publication_date": "2026-07"}},
+        {"publication_date": "2026-07-16"},
+    ).publication_date_eval()
+
+    assert result["score"] == 1.0
+
+
+def test_null_ground_truth_is_excluded_and_spurious_output_is_counted():
+    """Absent GT cannot improve accuracy and fabricated values are counted."""
+    result = build_comparison_payload(
+        {"title": "Expected title", "doi": "10.1234/invented"},
+        {"title": "Expected title"},
+    )
+
+    assert result["average_score"] == 1.0
+    assert result["gt_field_count"] == 1
+    assert result["spurious_count"] == 1
+
+
+def test_creator_attributes_stay_attached_to_their_authors():
+    """Swapped ORCIDs receive no per-author credit."""
+    expected = {
+        "creators": [
+            {"name": "Doe, Jane", "orcid": "0000-0002-1111-1115"},
+            {"name": "Smith, John", "orcid": "0000-0002-1825-0097"},
+        ]
+    }
+    predicted = {
+        "creators": [
+            {"name": "Jane Doe", "orcid": "0000-0002-1825-0097"},
+            {"name": "John Smith", "orcid": "0000-0002-1111-1115"},
+        ]
+    }
+
+    result = Evaluator({"expected_output": expected}, predicted).creators_eval()
+
+    assert result["creators_orcid"]["score"] == 1.0
+    assert result["creators_orcid_indexed"]["score"] == 0.0


### PR DESCRIPTION
This PR adds the [evals](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) pipeline to Orcha, including local dataset loading, prompt syncing, extractor support, and a sweep script for running evaluations across multiple extractors and prompts. It also adds the pdfinspector extractor and updates dependencies for the evaluation flow. There is still significant duplication with code already in Orcha, so the next step will be to remove that duplication and consolidate shared logic.